### PR TITLE
单击块选中和多文本选中后点击手柄进行多块选中

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -4,7 +4,7 @@ import builtins from "builtin-modules";
 import fs from "fs";
 
 const prod = process.argv[2] === "production";
-const pluginDir = "C:/Users/19411_4bs7lzt/OneDrive/obsidian/.obsidian/plugins/dragger";
+const pluginDir = "/Users/jinyujia/Downloads/test/.obsidian/plugins/dragger";
 
 // 复制 styles.css 到插件目录
 function copyStyles() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dragger",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "dragger",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "license": "MIT",
             "devDependencies": {
                 "@codemirror/state": "^6.0.0",

--- a/src/editor/core/constants.ts
+++ b/src/editor/core/constants.ts
@@ -63,3 +63,4 @@ export function setAlignToLineNumber(align: boolean): void {
  */
 export const HOVER_HIDDEN_LINE_NUMBER_CLASS = 'dnd-line-number-hover-hidden';
 export const GRAB_HIDDEN_LINE_NUMBER_CLASS = 'dnd-line-number-grab-hidden';
+export const BLOCK_SELECTION_ACTIVE_CLASS = 'dnd-block-selection-active';

--- a/src/editor/core/constants.ts
+++ b/src/editor/core/constants.ts
@@ -29,7 +29,7 @@ export const HANDLE_INTERACTION_ZONE_PX = 64;
  * Centralised mutable config – set once per plugin load via `applySettings()`.
  */
 const handleConfig = {
-    sizePx: 16,
+    sizePx: 24,
     horizontalOffsetPx: 0,
     alignToLineNumber: true,
 };
@@ -39,7 +39,7 @@ export function getHandleSizePx(): number {
 }
 
 export function setHandleSizePx(size: number): void {
-    handleConfig.sizePx = Math.max(12, Math.min(28, size));
+    handleConfig.sizePx = Math.max(12, Math.min(36, size));
 }
 
 export function getHandleHorizontalOffsetPx(): number {

--- a/src/editor/core/line-map.spec.ts
+++ b/src/editor/core/line-map.spec.ts
@@ -208,8 +208,6 @@ describe('line-map', () => {
             get: summarizeDurations(getDurations),
         };
 
-        console.debug('[Dragger][PerfTest] typing_line_map', JSON.stringify(report, null, 2));
-
         expect(report.total.count).toBe(iterations);
         expect(report.prime.p95).toBeGreaterThanOrEqual(0);
         expect(report.get.p95).toBeGreaterThanOrEqual(0);

--- a/src/editor/core/perf-session.ts
+++ b/src/editor/core/perf-session.ts
@@ -93,10 +93,6 @@ function summarize(values: number[]): { count: number; p50: number; p95: number;
     };
 }
 
-function serializeSnapshot(snapshot: DragPerfSnapshot): string {
-    return JSON.stringify(snapshot, null, 2);
-}
-
 export function createDragPerfSession(input: DragPerfSessionInput): DragPerfSession {
     const startedAtMs = nowMs();
     const durations = createDurationStore();
@@ -145,8 +141,6 @@ export function createDragPerfSession(input: DragPerfSessionInput): DragPerfSess
     };
 }
 
-export function logDragPerfSession(session: DragPerfSession | null, reason: string): void {
-    if (!session) return;
-    const snapshot = session.snapshot();
-    console.debug('[Dragger][Perf]', reason, serializeSnapshot(snapshot));
+export function logDragPerfSession(_session: DragPerfSession | null, _reason: string): void {
+    // no-op in normal runtime
 }

--- a/src/editor/core/selectors.ts
+++ b/src/editor/core/selectors.ts
@@ -15,4 +15,5 @@ export const DRAG_SOURCE_LINE_NUMBER_CLASS = 'dnd-drag-source-line-number';
 export const RANGE_SELECTED_LINE_CLASS = 'dnd-range-selected-line';
 export const RANGE_SELECTED_HANDLE_CLASS = 'dnd-range-selected-handle';
 export const RANGE_SELECTION_LINK_CLASS = 'dnd-range-selection-link';
+export const SELECTION_HIGHLIGHT_LINE_CLASS = 'dnd-selection-highlight-line';
 export const MOBILE_GESTURE_LOCK_CLASS = 'dnd-mobile-gesture-lock';

--- a/src/editor/core/services/EditorSelectionBridge.ts
+++ b/src/editor/core/services/EditorSelectionBridge.ts
@@ -1,6 +1,10 @@
 import type { EditorView } from '@codemirror/view';
 import type { LineRange } from '../../../types';
-import { resolveBlockBoundaryAtLine, resolveBlockAlignedLineRange } from '../../interaction/RangeSelectionLogic';
+import {
+    mergeLineRanges,
+    resolveBlockAlignedLineRange,
+    resolveBlockBoundaryAtLine,
+} from '../../interaction/RangeSelectionLogic';
 
 export type EditorTextSelection = {
     from: number;
@@ -22,33 +26,45 @@ export class EditorSelectionBridge {
      * @returns Selection info if there's a valid non-empty selection, null otherwise
      */
     getTextSelection(): EditorTextSelection | null {
-        const selection = this.view.state.selection;
-        const main = selection.main;
+        return this.getTextSelections()[0] ?? null;
+    }
 
-        // Empty selection (just cursor position) is not a valid selection
-        if (main.empty) {
-            return null;
-        }
-
+    /**
+     * Get all non-empty text selections in the editor.
+     * Supports multi-range selections (e.g. multiple carets/ranges).
+     */
+    getTextSelections(): EditorTextSelection[] {
         const doc = this.view.state.doc;
-        const fromLine = doc.lineAt(main.from).number;
-        const toLine = doc.lineAt(main.to).number;
+        const ranges = this.view.state.selection.ranges;
+        const selections: EditorTextSelection[] = [];
 
-        return {
-            from: main.from,
-            to: main.to,
-            fromLine,
-            toLine,
-        };
+        for (const range of ranges) {
+            if (range.empty) continue;
+            const fromLine = doc.lineAt(range.from).number;
+            const toLine = doc.lineAt(range.to).number;
+            selections.push({
+                from: range.from,
+                to: range.to,
+                fromLine,
+                toLine,
+            });
+        }
+        console.log('[Dragger Debug] EditorSelectionBridge.getTextSelections', {
+            count: selections.length,
+            selections,
+        });
+        return selections;
     }
 
     /**
      * Check if a line number is within the current editor selection.
      */
     isLineInSelection(lineNumber: number): boolean {
-        const selection = this.getTextSelection();
-        if (!selection) return false;
-        return lineNumber >= selection.fromLine && lineNumber <= selection.toLine;
+        const selections = this.getTextSelections();
+        if (selections.length === 0) return false;
+        return selections.some((selection) => (
+            lineNumber >= selection.fromLine && lineNumber <= selection.toLine
+        ));
     }
 
     /**
@@ -57,28 +73,37 @@ export class EditorSelectionBridge {
      * @returns Block-aligned line ranges, or null if no valid selection
      */
     resolveBlockAlignedSelection(): LineRange[] | null {
-        const selection = this.getTextSelection();
-        if (!selection) return null;
+        const selections = this.getTextSelections();
+        if (selections.length === 0) return null;
 
         const state = this.view.state;
+        const docLines = state.doc.lines;
+        const ranges: LineRange[] = [];
 
-        // Get the block boundaries at the selection start and end
-        const startBoundary = resolveBlockBoundaryAtLine(state, selection.fromLine);
-        const endBoundary = resolveBlockBoundaryAtLine(state, selection.toLine);
+        for (const selection of selections) {
+            // Get the block boundaries at the selection start and end
+            const startBoundary = resolveBlockBoundaryAtLine(state, selection.fromLine);
+            const endBoundary = resolveBlockBoundaryAtLine(state, selection.toLine);
 
-        // Resolve to block-aligned range
-        const aligned = resolveBlockAlignedLineRange(
-            state,
-            startBoundary.startLineNumber,
-            startBoundary.endLineNumber,
-            endBoundary.startLineNumber,
-            endBoundary.endLineNumber
-        );
-
-        return [{
-            startLineNumber: aligned.startLineNumber,
-            endLineNumber: aligned.endLineNumber,
-        }];
+            // Resolve to block-aligned range
+            const aligned = resolveBlockAlignedLineRange(
+                state,
+                startBoundary.startLineNumber,
+                startBoundary.endLineNumber,
+                endBoundary.startLineNumber,
+                endBoundary.endLineNumber
+            );
+            ranges.push({
+                startLineNumber: aligned.startLineNumber,
+                endLineNumber: aligned.endLineNumber,
+            });
+        }
+        const merged = mergeLineRanges(docLines, ranges);
+        console.log('[Dragger Debug] EditorSelectionBridge.resolveBlockAlignedSelection', {
+            inputSelections: selections,
+            blockRanges: merged,
+        });
+        return merged;
     }
 
     /**
@@ -88,11 +113,32 @@ export class EditorSelectionBridge {
      * @returns Block-aligned ranges if the line intersects, null otherwise
      */
     getBlockAlignedRangeIfIntersecting(lineNumber: number): LineRange[] | null {
-        const selection = this.getTextSelection();
-        if (!selection) return null;
+        return this.getBlockAlignedRangeIfRangeIntersecting(lineNumber, lineNumber);
+    }
 
-        // Check if the line is within the selection range
-        if (!this.isLineInSelection(lineNumber)) return null;
+    /**
+     * Check if a line range intersects with the editor selection.
+     * If it does, return the block-aligned selection ranges.
+     * @param startLineNumber Inclusive start line number (1-indexed)
+     * @param endLineNumber Inclusive end line number (1-indexed)
+     */
+    getBlockAlignedRangeIfRangeIntersecting(startLineNumber: number, endLineNumber: number): LineRange[] | null {
+        const selections = this.getTextSelections();
+        if (selections.length === 0) return null;
+
+        const safeStart = Math.min(startLineNumber, endLineNumber);
+        const safeEnd = Math.max(startLineNumber, endLineNumber);
+
+        // Trigger only when clicked range intersects at least one text selection range.
+        const intersects = selections.some((selection) => (
+            safeEnd >= selection.fromLine && safeStart <= selection.toLine
+        ));
+        console.log('[Dragger Debug] EditorSelectionBridge.getBlockAlignedRangeIfRangeIntersecting', {
+            blockRange: { startLineNumber: safeStart, endLineNumber: safeEnd },
+            selections,
+            intersects,
+        });
+        if (!intersects) return null;
 
         // Return the block-aligned selection
         return this.resolveBlockAlignedSelection();

--- a/src/editor/core/services/EditorSelectionBridge.ts
+++ b/src/editor/core/services/EditorSelectionBridge.ts
@@ -1,0 +1,100 @@
+import type { EditorView } from '@codemirror/view';
+import type { LineRange } from '../../../types';
+import { resolveBlockBoundaryAtLine, resolveBlockAlignedLineRange } from '../../interaction/RangeSelectionLogic';
+
+export type EditorTextSelection = {
+    from: number;
+    to: number;
+    fromLine: number;
+    toLine: number;
+};
+
+/**
+ * Bridge between CodeMirror editor selection and block-based selection.
+ * Reads the editor's native text selection and converts it to line ranges
+ * that can be used for block-aligned multi-line selection.
+ */
+export class EditorSelectionBridge {
+    constructor(private readonly view: EditorView) {}
+
+    /**
+     * Get the current text selection in the editor.
+     * @returns Selection info if there's a valid non-empty selection, null otherwise
+     */
+    getTextSelection(): EditorTextSelection | null {
+        const selection = this.view.state.selection;
+        const main = selection.main;
+
+        // Empty selection (just cursor position) is not a valid selection
+        if (main.empty) {
+            return null;
+        }
+
+        const doc = this.view.state.doc;
+        const fromLine = doc.lineAt(main.from).number;
+        const toLine = doc.lineAt(main.to).number;
+
+        return {
+            from: main.from,
+            to: main.to,
+            fromLine,
+            toLine,
+        };
+    }
+
+    /**
+     * Check if a line number is within the current editor selection.
+     */
+    isLineInSelection(lineNumber: number): boolean {
+        const selection = this.getTextSelection();
+        if (!selection) return false;
+        return lineNumber >= selection.fromLine && lineNumber <= selection.toLine;
+    }
+
+    /**
+     * Convert the current editor selection to block-aligned line ranges.
+     * This ensures that partial selections are expanded to include complete blocks.
+     * @returns Block-aligned line ranges, or null if no valid selection
+     */
+    resolveBlockAlignedSelection(): LineRange[] | null {
+        const selection = this.getTextSelection();
+        if (!selection) return null;
+
+        const state = this.view.state;
+
+        // Get the block boundaries at the selection start and end
+        const startBoundary = resolveBlockBoundaryAtLine(state, selection.fromLine);
+        const endBoundary = resolveBlockBoundaryAtLine(state, selection.toLine);
+
+        // Resolve to block-aligned range
+        const aligned = resolveBlockAlignedLineRange(
+            state,
+            startBoundary.startLineNumber,
+            startBoundary.endLineNumber,
+            endBoundary.startLineNumber,
+            endBoundary.endLineNumber
+        );
+
+        return [{
+            startLineNumber: aligned.startLineNumber,
+            endLineNumber: aligned.endLineNumber,
+        }];
+    }
+
+    /**
+     * Check if a line number intersects with the editor selection.
+     * If it does, return the block-aligned selection ranges.
+     * @param lineNumber The line number to check (1-indexed)
+     * @returns Block-aligned ranges if the line intersects, null otherwise
+     */
+    getBlockAlignedRangeIfIntersecting(lineNumber: number): LineRange[] | null {
+        const selection = this.getTextSelection();
+        if (!selection) return null;
+
+        // Check if the line is within the selection range
+        if (!this.isLineInSelection(lineNumber)) return null;
+
+        // Return the block-aligned selection
+        return this.resolveBlockAlignedSelection();
+    }
+}

--- a/src/editor/core/services/EditorSelectionBridge.ts
+++ b/src/editor/core/services/EditorSelectionBridge.ts
@@ -49,10 +49,6 @@ export class EditorSelectionBridge {
                 toLine,
             });
         }
-        console.log('[Dragger Debug] EditorSelectionBridge.getTextSelections', {
-            count: selections.length,
-            selections,
-        });
         return selections;
     }
 
@@ -98,12 +94,7 @@ export class EditorSelectionBridge {
                 endLineNumber: aligned.endLineNumber,
             });
         }
-        const merged = mergeLineRanges(docLines, ranges);
-        console.log('[Dragger Debug] EditorSelectionBridge.resolveBlockAlignedSelection', {
-            inputSelections: selections,
-            blockRanges: merged,
-        });
-        return merged;
+        return mergeLineRanges(docLines, ranges);
     }
 
     /**
@@ -133,11 +124,6 @@ export class EditorSelectionBridge {
         const intersects = selections.some((selection) => (
             safeEnd >= selection.fromLine && safeStart <= selection.toLine
         ));
-        console.log('[Dragger Debug] EditorSelectionBridge.getBlockAlignedRangeIfRangeIntersecting', {
-            blockRange: { startLineNumber: safeStart, endLineNumber: safeEnd },
-            selections,
-            intersects,
-        });
         if (!intersects) return null;
 
         // Return the block-aligned selection

--- a/src/editor/drag-handle.ts
+++ b/src/editor/drag-handle.ts
@@ -239,7 +239,12 @@ function createDragHandleViewPlugin(_plugin: DragNDropPlugin) {
                     this.refreshDecorationsAndEmbeds();
                 }
 
-                if (update.docChanged || update.geometryChanged) {
+                if (
+                    update.docChanged
+                    || update.geometryChanged
+                    || update.selectionSet
+                    || this.dragEventHandler.hasCommittedSelection()
+                ) {
                     this.dragEventHandler.refreshSelectionVisual();
                 }
                 const activeHandle2 = this.handleVisibility.getActiveHandle();

--- a/src/editor/drag-handle.ts
+++ b/src/editor/drag-handle.ts
@@ -179,6 +179,10 @@ function createDragHandleViewPlugin(_plugin: DragNDropPlugin) {
                     performDropAtPoint: (sourceBlock, clientX, clientY, pointerType) =>
                         this.orchestrator.performDropAtPoint(sourceBlock, clientX, clientY, pointerType ?? null),
                     onDragLifecycleEvent: (event) => this.orchestrator.emitDragLifecycle(event),
+                    setHiddenRangesForSelection: (ranges, anchorHandle) =>
+                        this.handleVisibility.setHiddenRangesForSelection(ranges, anchorHandle),
+                    clearHiddenRangesForSelection: () =>
+                        this.handleVisibility.clearHiddenRangesForSelection(),
                 });
 
                 this.semanticRefreshScheduler = new SemanticRefreshScheduler(this.view, {

--- a/src/editor/drag-handle.ts
+++ b/src/editor/drag-handle.ts
@@ -227,6 +227,7 @@ function createDragHandleViewPlugin(_plugin: DragNDropPlugin) {
                         this.reResolveActiveHandle();
                     }
                     this.handleVisibility.reapplySelectionHighlight();
+                    this.handleVisibility.reapplySelectionHandleVisibility();
                     return;
                 }
 
@@ -247,6 +248,7 @@ function createDragHandleViewPlugin(_plugin: DragNDropPlugin) {
                     this.reResolveActiveHandle();
                 }
                 this.handleVisibility.reapplySelectionHighlight();
+                this.handleVisibility.reapplySelectionHandleVisibility();
             }
 
             destroy(): void {

--- a/src/editor/interaction/DragEventHandler.spec.ts
+++ b/src/editor/interaction/DragEventHandler.spec.ts
@@ -2051,12 +2051,73 @@ describe('DragEventHandler', () => {
         expect(lines[2]?.classList.contains('dnd-range-selected-line')).toBe(true);
         expect(lines[3]?.classList.contains('dnd-range-selected-line')).toBe(true);
 
-        dispatchPointer(lines[5]!, 'pointerdown', {
+        dispatchPointer(lines[2]!, 'pointerdown', {
             pointerId: 112,
             pointerType: 'mouse',
             clientX: 220,
-            clientY: 120,
+            clientY: 50,
         });
+        lines = view.contentDOM.querySelectorAll<HTMLElement>('.cm-line');
+        expect(lines[1]?.classList.contains('dnd-range-selected-line')).toBe(false);
+        expect(lines[2]?.classList.contains('dnd-range-selected-line')).toBe(false);
+        expect(lines[3]?.classList.contains('dnd-range-selected-line')).toBe(false);
+        handler.destroy();
+    });
+
+    it('clears committed selection when clicking inside selected shaded lines with a new pointer', () => {
+        const view = createViewStub(8);
+        (view as unknown as { dispatch: (tr: { selection?: unknown }) => void }).dispatch = (tr) => {
+            if (tr.selection === undefined) return;
+            (view as unknown as { state: EditorState }).state = EditorState.create({
+                doc: view.state.doc.toString(),
+                selection: tr.selection as { anchor: number; head: number },
+            });
+        };
+        const handle = document.createElement('div');
+        handle.className = 'dnd-drag-handle';
+        handle.setAttribute('draggable', 'true');
+        view.dom.appendChild(handle);
+        applyTextSelection(view, 2, 4);
+
+        const baseBlock = createBlock('- item', 1, 1);
+        const handler = new DragEventHandler(view, {
+            getDragSourceBlock: () => null,
+            getBlockInfoForHandle: () => baseBlock,
+            getBlockInfoAtPoint: () => null,
+            isBlockInsideRenderedTableCell: () => false,
+            beginPointerDragSession: vi.fn(),
+            finishDragSession: vi.fn(),
+            scheduleDropIndicatorUpdate: vi.fn(),
+            hideDropIndicator: vi.fn(),
+            performDropAtPoint: vi.fn(),
+        });
+
+        handler.attach();
+        dispatchPointer(handle, 'pointerdown', {
+            pointerId: 301,
+            pointerType: 'mouse',
+            clientX: 12,
+            clientY: 30,
+        });
+        dispatchPointer(window, 'pointerup', {
+            pointerId: 301,
+            pointerType: 'mouse',
+            clientX: 12,
+            clientY: 30,
+        });
+
+        let lines = view.contentDOM.querySelectorAll<HTMLElement>('.cm-line');
+        expect(lines[1]?.classList.contains('dnd-range-selected-line')).toBe(true);
+        expect(lines[2]?.classList.contains('dnd-range-selected-line')).toBe(true);
+        expect(lines[3]?.classList.contains('dnd-range-selected-line')).toBe(true);
+
+        dispatchPointer(lines[2]!, 'pointerdown', {
+            pointerId: 302,
+            pointerType: 'mouse',
+            clientX: 220,
+            clientY: 50,
+        });
+
         lines = view.contentDOM.querySelectorAll<HTMLElement>('.cm-line');
         expect(lines[1]?.classList.contains('dnd-range-selected-line')).toBe(false);
         expect(lines[2]?.classList.contains('dnd-range-selected-line')).toBe(false);

--- a/src/editor/interaction/DragEventHandler.spec.ts
+++ b/src/editor/interaction/DragEventHandler.spec.ts
@@ -724,20 +724,18 @@ describe('DragEventHandler', () => {
             clientY: 105,
         });
 
-        let link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link).not.toBeNull();
-        expect(link?.classList.contains('is-active')).toBe(true);
+        expect(view.dom.querySelectorAll('.dnd-range-selected-line').length).toBeGreaterThan(0);
+        expect(view.dom.querySelector('.dnd-range-selection-link')).toBeNull();
 
-        dispatchPointer(view.contentDOM, 'pointerdown', {
+        const lines = view.contentDOM.querySelectorAll<HTMLElement>('.cm-line');
+        dispatchPointer(lines[7] ?? view.contentDOM, 'pointerdown', {
             pointerId: 42,
             pointerType: 'mouse',
             clientX: 220,
-            clientY: 40,
+            clientY: 170,
         });
 
-        link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link).not.toBeNull();
-        expect(link?.classList.contains('is-active')).toBe(false);
+        expect(view.dom.querySelector('.dnd-range-selection-link')).toBeNull();
         expect(view.dom.querySelector('.dnd-range-selected-line')).toBeNull();
         handler.destroy();
     });
@@ -2053,11 +2051,11 @@ describe('DragEventHandler', () => {
         expect(lines[2]?.classList.contains('dnd-range-selected-line')).toBe(true);
         expect(lines[3]?.classList.contains('dnd-range-selected-line')).toBe(true);
 
-        dispatchPointer(lines[2]!, 'pointerdown', {
+        dispatchPointer(lines[5]!, 'pointerdown', {
             pointerId: 112,
             pointerType: 'mouse',
             clientX: 220,
-            clientY: 50,
+            clientY: 120,
         });
         lines = view.contentDOM.querySelectorAll<HTMLElement>('.cm-line');
         expect(lines[1]?.classList.contains('dnd-range-selected-line')).toBe(false);

--- a/src/editor/interaction/DragEventHandler.spec.ts
+++ b/src/editor/interaction/DragEventHandler.spec.ts
@@ -173,6 +173,14 @@ function applyMultiTextSelections(view: EditorView, ranges: Array<{ fromLine: nu
     });
 }
 
+function getCommittedSelectionTarget(view: EditorView): HTMLElement {
+    const selected = view.contentDOM.querySelectorAll<HTMLElement>('.dnd-range-selected-line');
+    if (selected.length > 0) {
+        return selected[Math.floor(selected.length / 2)]!;
+    }
+    return view.contentDOM;
+}
+
 beforeEach(() => {
     if (!originalElementFromPoint && typeof document.elementFromPoint === 'function') {
         const native = document.elementFromPoint.bind(document);
@@ -257,9 +265,8 @@ describe('DragEventHandler', () => {
         });
 
         expect(beginPointerDragSession).not.toHaveBeenCalled();
-        const link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link).not.toBeNull();
-        expect(link?.classList.contains('is-active')).toBe(true);
+        const lines = view.contentDOM.querySelectorAll<HTMLElement>('.dnd-range-selected-line');
+        expect(lines.length).toBe(1);
         handler.destroy();
     });
 
@@ -361,12 +368,11 @@ describe('DragEventHandler', () => {
         });
         expect(beginPointerDragSession).not.toHaveBeenCalled();
 
-        const link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link).not.toBeNull();
-        dispatchPointer(link!, 'pointerdown', {
+        const committedTarget = getCommittedSelectionTarget(view);
+        dispatchPointer(committedTarget, 'pointerdown', {
             pointerId: 8,
             pointerType: 'mouse',
-            clientX: 12,
+            clientX: 0,
             clientY: 80,
         });
         vi.advanceTimersByTime(280);
@@ -441,13 +447,11 @@ describe('DragEventHandler', () => {
             clientY: 105,
         });
 
-        const link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link).not.toBeNull();
-
-        dispatchPointer(link!, 'pointerdown', {
+        const committedTarget = getCommittedSelectionTarget(view);
+        dispatchPointer(committedTarget, 'pointerdown', {
             pointerId: 71,
             pointerType: 'mouse',
-            clientX: 12,
+            clientX: 0,
             clientY: 80,
         });
         dispatchPointer(window, 'pointermove', {
@@ -503,9 +507,8 @@ describe('DragEventHandler', () => {
             clientY: 90,
         });
 
-        const link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link).not.toBeNull();
-        expect(link?.classList.contains('is-active')).toBe(true);
+        const lines = view.contentDOM.querySelectorAll<HTMLElement>('.dnd-range-selected-line');
+        expect(lines.length).toBeGreaterThan(0);
         handler.destroy();
     });
 
@@ -645,12 +648,11 @@ describe('DragEventHandler', () => {
         });
         expect(beginPointerDragSession).not.toHaveBeenCalled();
 
-        const link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link).not.toBeNull();
-        dispatchPointer(link!, 'pointerdown', {
+        const committedTarget = getCommittedSelectionTarget(view);
+        dispatchPointer(committedTarget, 'pointerdown', {
             pointerId: 19,
             pointerType: 'touch',
-            clientX: 12,
+            clientX: 32,
             clientY: 80,
         });
         vi.advanceTimersByTime(120);
@@ -781,8 +783,8 @@ describe('DragEventHandler', () => {
             clientY: 105,
         });
 
-        let link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link?.classList.contains('is-active')).toBe(true);
+        let lines = view.contentDOM.querySelectorAll<HTMLElement>('.dnd-range-selected-line');
+        expect(lines.length).toBeGreaterThan(0);
 
         dispatchPointer(view.contentDOM, 'pointerdown', {
             pointerId: 62,
@@ -791,15 +793,15 @@ describe('DragEventHandler', () => {
             clientY: 40,
         });
 
-        link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link?.classList.contains('is-active')).toBe(true);
+        lines = view.contentDOM.querySelectorAll<HTMLElement>('.dnd-range-selected-line');
+        expect(lines.length).toBeGreaterThan(0);
 
         const input = document.createElement('textarea');
         view.dom.appendChild(input);
         input.dispatchEvent(new FocusEvent('focusin', { bubbles: true, cancelable: true }));
 
-        link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link?.classList.contains('is-active')).toBe(false);
+        lines = view.contentDOM.querySelectorAll<HTMLElement>('.dnd-range-selected-line');
+        expect(lines.length).toBe(0);
         handler.destroy();
     });
 
@@ -852,16 +854,16 @@ describe('DragEventHandler', () => {
             clientY: 105,
         });
 
-        const link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link).not.toBeNull();
-        const topBefore = Number(link?.style.top.replace('px', '') || '0');
+        let selectedLines = view.contentDOM.querySelectorAll<HTMLElement>('.dnd-range-selected-line');
+        const countBefore = selectedLines.length;
+        expect(countBefore).toBeGreaterThan(0);
 
         scrollOffset = 40;
         view.dom.dispatchEvent(new Event('scroll'));
         vi.advanceTimersByTime(20);
 
-        const topAfter = Number(link?.style.top.replace('px', '') || '0');
-        expect(topAfter).toBeLessThan(topBefore);
+        selectedLines = view.contentDOM.querySelectorAll<HTMLElement>('.dnd-range-selected-line');
+        expect(selectedLines.length).toBe(countBefore);
         handler.destroy();
     });
 
@@ -930,12 +932,11 @@ describe('DragEventHandler', () => {
         });
         expect(beginPointerDragSession).not.toHaveBeenCalled();
 
-        const link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link).not.toBeNull();
-        dispatchPointer(link!, 'pointerdown', {
+        const committedTarget = getCommittedSelectionTarget(view);
+        dispatchPointer(committedTarget, 'pointerdown', {
             pointerId: 10,
             pointerType: 'mouse',
-            clientX: 12,
+            clientX: 0,
             clientY: 25,
         });
         vi.advanceTimersByTime(280);
@@ -1048,12 +1049,11 @@ describe('DragEventHandler', () => {
         });
         expect(beginPointerDragSession).not.toHaveBeenCalled();
 
-        const link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link).not.toBeNull();
-        dispatchPointer(link!, 'pointerdown', {
+        const committedTarget = getCommittedSelectionTarget(view);
+        dispatchPointer(committedTarget, 'pointerdown', {
             pointerId: 12,
             pointerType: 'mouse',
-            clientX: 12,
+            clientX: 0,
             clientY: 92,
         });
         vi.advanceTimersByTime(280);
@@ -1150,14 +1150,12 @@ describe('DragEventHandler', () => {
             clientY: 150,
         });
 
-        const link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link).not.toBeNull();
-
-        dispatchPointer(link!, 'pointerdown', {
+        const committedTarget = getCommittedSelectionTarget(view);
+        dispatchPointer(committedTarget, 'pointerdown', {
             pointerId: 32,
             pointerType: 'mouse',
-            clientX: 12,
-            clientY: 80,
+            clientX: 0,
+            clientY: 30,
         });
         vi.advanceTimersByTime(280);
         dispatchPointer(window, 'pointermove', {
@@ -1305,9 +1303,8 @@ describe('DragEventHandler', () => {
         });
         expect(beginPointerDragSession).not.toHaveBeenCalled();
 
-        const link = view.dom.querySelector<HTMLElement>('.dnd-range-selection-link');
-        expect(link).not.toBeNull();
-        dispatchPointer(link!, 'pointerdown', {
+        const committedTarget = getCommittedSelectionTarget(view);
+        dispatchPointer(committedTarget, 'pointerdown', {
             pointerId: 3,
             pointerType: 'touch',
             clientX: 32,
@@ -1494,7 +1491,7 @@ describe('DragEventHandler', () => {
             endLine: 1,
         }), 'touch');
         const lines = view.contentDOM.querySelectorAll<HTMLElement>('.cm-line');
-        expect(lines[3]?.classList.contains('dnd-range-selected-line')).toBe(true);
+        expect(lines[2]?.classList.contains('dnd-range-selected-line')).toBe(true);
         expect(lines[1]?.classList.contains('dnd-range-selected-line')).toBe(false);
         expect(view.dom.querySelector('.dnd-range-selection-link')).toBeNull();
         expect(performDropAtPoint).toHaveBeenCalledTimes(1);
@@ -2176,6 +2173,118 @@ describe('DragEventHandler', () => {
         expect(lines[5]?.classList.contains('dnd-range-selected-line')).toBe(true);
         expect(lines[2]?.classList.contains('dnd-range-selected-line')).toBe(false);
         expect(lines[4]?.classList.contains('dnd-range-selected-line')).toBe(false);
+        handler.destroy();
+    });
+
+    it('does not reuse stale text-selection snapshot for a later handle click', () => {
+        const view = createViewStub(10);
+        const handleA = document.createElement('div');
+        handleA.className = 'dnd-drag-handle';
+        handleA.setAttribute('draggable', 'true');
+        const handleB = document.createElement('div');
+        handleB.className = 'dnd-drag-handle';
+        handleB.setAttribute('draggable', 'true');
+        view.dom.appendChild(handleA);
+        view.dom.appendChild(handleB);
+
+        const blockA = createBlock('- item A', 1, 1);
+        const blockB = createBlock('- item B', 5, 5);
+        applyTextSelection(view, 2, 4);
+
+        const handler = new DragEventHandler(view, {
+            getDragSourceBlock: () => null,
+            getBlockInfoForHandle: (handle) => {
+                if (handle === handleA) return blockA;
+                if (handle === handleB) return blockB;
+                return null;
+            },
+            getBlockInfoAtPoint: () => null,
+            isBlockInsideRenderedTableCell: () => false,
+            beginPointerDragSession: vi.fn(),
+            finishDragSession: vi.fn(),
+            scheduleDropIndicatorUpdate: vi.fn(),
+            hideDropIndicator: vi.fn(),
+            performDropAtPoint: vi.fn(),
+        });
+
+        handler.attach();
+
+        // First pointerdown captures a text-selection snapshot, but does not click any handle.
+        const linesBefore = view.contentDOM.querySelectorAll<HTMLElement>('.cm-line');
+        dispatchPointer(linesBefore[0]!, 'pointerdown', {
+            pointerId: 401,
+            pointerType: 'mouse',
+            clientX: 220,
+            clientY: 10,
+        });
+
+        // Clear live editor selection so later smart-selection must not use stale snapshot.
+        (view as unknown as { state: EditorState }).state = EditorState.create({
+            doc: view.state.doc.toString(),
+        });
+
+        dispatchPointer(handleB, 'pointerdown', {
+            pointerId: 402,
+            pointerType: 'mouse',
+            clientX: 12,
+            clientY: 110,
+        });
+        dispatchPointer(window, 'pointerup', {
+            pointerId: 402,
+            pointerType: 'mouse',
+            clientX: 12,
+            clientY: 110,
+        });
+
+        const lines = view.contentDOM.querySelectorAll<HTMLElement>('.cm-line');
+        expect(lines[5]?.classList.contains('dnd-range-selected-line')).toBe(true);
+        expect(lines[1]?.classList.contains('dnd-range-selected-line')).toBe(false);
+        expect(lines[2]?.classList.contains('dnd-range-selected-line')).toBe(false);
+        expect(lines[3]?.classList.contains('dnd-range-selected-line')).toBe(false);
+        handler.destroy();
+    });
+
+    it('preserves source block type after drop-restore selection', () => {
+        const view = createViewStub(8);
+        const sourceBlock = createBlock('- item', 1, 1);
+        const movedBlockAtTarget = createBlock('- item moved', 3, 3);
+        const performDropAtPoint = vi.fn(() => 5);
+        const handler = new DragEventHandler(view, {
+            getDragSourceBlock: (e) => {
+                const raw = e.dataTransfer?.getData('application/dnd-block') ?? '';
+                if (!raw) return null;
+                return JSON.parse(raw) as BlockInfo;
+            },
+            getBlockInfoForHandle: () => movedBlockAtTarget,
+            getBlockInfoAtPoint: () => null,
+            isBlockInsideRenderedTableCell: () => false,
+            beginPointerDragSession: vi.fn(),
+            finishDragSession: vi.fn(),
+            scheduleDropIndicatorUpdate: vi.fn(),
+            hideDropIndicator: vi.fn(),
+            performDropAtPoint,
+        });
+
+        handler.attach();
+        dispatchDrop(view.dom, {
+            clientX: 120,
+            clientY: 90,
+            dataTransfer: {
+                types: ['application/dnd-block'],
+                getData: (type: string) => {
+                    if (type === 'application/dnd-block') {
+                        return JSON.stringify(sourceBlock);
+                    }
+                    return '';
+                },
+                dropEffect: 'move',
+            },
+        });
+        vi.advanceTimersByTime(1);
+
+        const resolved = handler.resolveNativeDragSourceForHandleDrag(movedBlockAtTarget);
+        expect(resolved?.type).toBe(BlockType.ListItem);
+        expect(performDropAtPoint).toHaveBeenCalledTimes(1);
         handler.destroy();
     });
 });

--- a/src/editor/interaction/DragEventHandler.ts
+++ b/src/editor/interaction/DragEventHandler.ts
@@ -7,7 +7,6 @@ import {
 import {
     DRAG_HANDLE_CLASS,
     EMBED_HANDLE_CLASS,
-    RANGE_SELECTED_LINE_CLASS,
     RANGE_SELECTED_HANDLE_CLASS,
     RANGE_SELECTION_LINK_CLASS,
 } from '../core/selectors';
@@ -1259,19 +1258,16 @@ export class DragEventHandler {
         const isLink = target.closest(`.${RANGE_SELECTION_LINK_CLASS}`);
         const isSelectedHandle = target.closest(`.${RANGE_SELECTED_HANDLE_CLASS}`);
         const isHandle = target.closest(`.${DRAG_HANDLE_CLASS}`);
-        const isSelectedLine = target.closest(`.${RANGE_SELECTED_LINE_CLASS}`);
         console.log('[Dragger Debug] shouldClearCommittedSelectionOnPointerDown', {
             targetClass: target.className,
             isLink: !!isLink,
             isSelectedHandle: !!isSelectedHandle,
             isHandle: !!isHandle,
-            isSelectedLine: !!isSelectedLine,
             clientX,
         });
         if (isLink) return false;
         if (isSelectedHandle) return false;
         if (isHandle) return false;
-        if (isSelectedLine) return false;
 
         if (pointerType && pointerType !== 'mouse') {
             if (!this.mobile.isWithinContentTolerance(clientX)) {

--- a/src/editor/interaction/DragEventHandler.ts
+++ b/src/editor/interaction/DragEventHandler.ts
@@ -470,16 +470,18 @@ export class DragEventHandler {
         const isMouse = pointerType === 'mouse';
         const sourceHandleDraggableAttr = handle?.getAttribute('draggable') ?? null;
 
-        // Always prevent default and stop propagation for smart selection
-        // to avoid the selection being cleared by other handlers
-        e.preventDefault();
-        e.stopPropagation();
+        // For non-mouse (touch), prevent default and capture pointer
+        // For mouse, allow native HTML5 drag to work
         if (!isMouse) {
+            e.preventDefault();
+            e.stopPropagation();
             this.pointer.tryCapturePointer(e);
+            if (handle) {
+                handle.setAttribute('draggable', 'false');
+            }
         }
-        if (handle) {
-            handle.setAttribute('draggable', 'false');
-        }
+        // For mouse: don't prevent default - let native drag work
+        // The timeout will commit selection, and native drag will use resolveNativeDragSourceForHandleDrag
 
         const anchorStartLineNumber = precomputedRanges[0].startLineNumber;
         const anchorEndLineNumber = precomputedRanges[precomputedRanges.length - 1].endLineNumber;

--- a/src/editor/interaction/DragEventHandler.ts
+++ b/src/editor/interaction/DragEventHandler.ts
@@ -794,6 +794,10 @@ export class DragEventHandler {
             ranges: committedRanges,
         };
         this.rangeVisual.render(committedRanges, { showLinks: state.showLinks, highlightHandles: state.highlightHandles });
+        // Hide handles for non-anchor blocks during selection
+        if (this.deps.setHiddenRangesForSelection) {
+            this.deps.setHiddenRangesForSelection(committedRanges, state.sourceHandle);
+        }
     }
 
     private clearCommittedRangeSelection(): void {

--- a/src/editor/interaction/DragEventHandler.ts
+++ b/src/editor/interaction/DragEventHandler.ts
@@ -388,6 +388,7 @@ export class DragEventHandler {
             committedRangesSnapshot,
             selectionRanges: initialRanges,
             showLinks: true,
+            highlightHandles: true,
         } };
         this.pointer.attachPointerListeners();
         this.emitLifecycle({
@@ -467,11 +468,12 @@ export class DragEventHandler {
                 committedRangesSnapshot: [],
                 selectionRanges: precomputedRanges,
                 showLinks: false,
+                highlightHandles: false,
             },
         };
 
-        // Immediately render the selection visual (without the vertical link line)
-        this.rangeVisual.render(precomputedRanges, false);
+        // Immediately render the selection visual (without link line or handle highlights)
+        this.rangeVisual.render(precomputedRanges, { showLinks: false, highlightHandles: false });
         this.pointer.attachPointerListeners();
 
         this.emitLifecycle({
@@ -772,7 +774,7 @@ export class DragEventHandler {
             state.sourceBlock
         );
 
-        this.rangeVisual.render(state.selectionRanges);
+        this.rangeVisual.render(state.selectionRanges, { showLinks: state.showLinks, highlightHandles: state.highlightHandles });
     }
 
     private commitRangeSelection(state: MouseRangeSelectState): void {
@@ -783,7 +785,7 @@ export class DragEventHandler {
             selectedBlock: committedBlock,
             ranges: committedRanges,
         };
-        this.rangeVisual.render(committedRanges, state.showLinks);
+        this.rangeVisual.render(committedRanges, { showLinks: state.showLinks, highlightHandles: state.highlightHandles });
     }
 
     private clearCommittedRangeSelection(): void {
@@ -799,10 +801,13 @@ export class DragEventHandler {
 
     private refreshRangeSelectionVisual(): void {
         if (this.gesture.phase === 'range_selecting') {
-            this.rangeVisual.render(this.gesture.rangeSelect.selectionRanges);
+            const state = this.gesture.rangeSelect;
+            this.rangeVisual.render(state.selectionRanges, { showLinks: state.showLinks, highlightHandles: state.highlightHandles });
             return;
         }
         if (this.committedRangeSelection) {
+            // For committed selections, use default (show links and handles)
+            // since we don't store these flags in committedRangeSelection
             this.rangeVisual.render(this.committedRangeSelection.ranges);
         }
     }

--- a/src/editor/interaction/DragEventHandler.ts
+++ b/src/editor/interaction/DragEventHandler.ts
@@ -7,6 +7,7 @@ import {
 import {
     DRAG_HANDLE_CLASS,
     EMBED_HANDLE_CLASS,
+    RANGE_SELECTED_LINE_CLASS,
     RANGE_SELECTED_HANDLE_CLASS,
     RANGE_SELECTION_LINK_CLASS,
 } from '../core/selectors';
@@ -344,6 +345,10 @@ export class DragEventHandler {
 
     isGestureActive(): boolean {
         return this.hasActivePointerSession();
+    }
+
+    hasCommittedSelection(): boolean {
+        return this.committedRangeSelection !== null;
     }
 
     refreshSelectionVisual(): void {
@@ -1254,16 +1259,19 @@ export class DragEventHandler {
         const isLink = target.closest(`.${RANGE_SELECTION_LINK_CLASS}`);
         const isSelectedHandle = target.closest(`.${RANGE_SELECTED_HANDLE_CLASS}`);
         const isHandle = target.closest(`.${DRAG_HANDLE_CLASS}`);
+        const isSelectedLine = target.closest(`.${RANGE_SELECTED_LINE_CLASS}`);
         console.log('[Dragger Debug] shouldClearCommittedSelectionOnPointerDown', {
             targetClass: target.className,
             isLink: !!isLink,
             isSelectedHandle: !!isSelectedHandle,
             isHandle: !!isHandle,
+            isSelectedLine: !!isSelectedLine,
             clientX,
         });
         if (isLink) return false;
         if (isSelectedHandle) return false;
         if (isHandle) return false;
+        if (isSelectedLine) return false;
 
         if (pointerType && pointerType !== 'mouse') {
             if (!this.mobile.isWithinContentTolerance(clientX)) {

--- a/src/editor/interaction/DragEventHandler.ts
+++ b/src/editor/interaction/DragEventHandler.ts
@@ -389,8 +389,8 @@ export class DragEventHandler {
             currentLineNumber: anchorEndLineNumber,
             committedRangesSnapshot,
             selectionRanges: initialRanges,
-            showLinks: true,
-            highlightHandles: true,
+            showLinks: false,
+            highlightHandles: false,
         } };
         this.pointer.attachPointerListeners();
         this.emitLifecycle({
@@ -931,7 +931,10 @@ export class DragEventHandler {
         if (this.gesture.phase === 'range_selecting') {
             const rangeState = this.gesture.rangeSelect;
             if (e.pointerId === rangeState.pointerId) {
-                if (!rangeState.longPressReady) {
+                // For mouse, commit selection even on quick click (longPressReady=false)
+                // For touch, require longPressReady to be true
+                const isMouse = rangeState.pointerType === 'mouse';
+                if (!rangeState.longPressReady && !isMouse) {
                     this.abortPointerSession({
                         shouldFinishDragSession: false,
                         shouldHideDropIndicator: false,

--- a/src/editor/interaction/DragEventHandler.ts
+++ b/src/editor/interaction/DragEventHandler.ts
@@ -1,4 +1,5 @@
 import { EditorView } from '@codemirror/view';
+import { EditorSelection } from '@codemirror/state';
 import { BlockInfo, DragLifecycleEvent } from '../../types';
 import {
     getHandleColumnCenterX,
@@ -419,6 +420,12 @@ export class DragEventHandler {
         if (handle) {
             handle.setAttribute('draggable', 'false');
         }
+
+        // Clear the editor's text selection to avoid visual confusion
+        const currentSelection = this.view.state.selection.main;
+        this.view.dispatch({
+            selection: EditorSelection.cursor(currentSelection.head),
+        });
 
         const anchorStartLineNumber = precomputedRanges[0].startLineNumber;
         const anchorEndLineNumber = precomputedRanges[precomputedRanges.length - 1].endLineNumber;

--- a/src/editor/interaction/DragEventHandler.ts
+++ b/src/editor/interaction/DragEventHandler.ts
@@ -468,8 +468,8 @@ export class DragEventHandler {
             },
         };
 
-        // Immediately render the selection visual
-        this.rangeVisual.render(precomputedRanges);
+        // Immediately render the selection visual (without the vertical link line)
+        this.rangeVisual.render(precomputedRanges, false);
         this.pointer.attachPointerListeners();
 
         this.emitLifecycle({

--- a/src/editor/interaction/DragEventHandler.ts
+++ b/src/editor/interaction/DragEventHandler.ts
@@ -76,6 +76,8 @@ export interface DragEventHandlerDeps {
     hideDropIndicator: () => void;
     performDropAtPoint: (sourceBlock: BlockInfo, clientX: number, clientY: number, pointerType: string | null) => void;
     onDragLifecycleEvent?: (event: DragLifecycleEvent) => void;
+    setHiddenRangesForSelection?: (ranges: Array<{ startLineNumber: number; endLineNumber: number }>, anchorHandle: HTMLElement | null) => void;
+    clearHiddenRangesForSelection?: () => void;
 }
 
 export class DragEventHandler {
@@ -474,6 +476,12 @@ export class DragEventHandler {
 
         // Immediately render the selection visual (without link line or handle highlights)
         this.rangeVisual.render(precomputedRanges, { showLinks: false, highlightHandles: false });
+
+        // Hide handles for selected blocks except the anchor handle
+        if (this.deps.setHiddenRangesForSelection) {
+            this.deps.setHiddenRangesForSelection(precomputedRanges, handle);
+        }
+
         this.pointer.attachPointerListeners();
 
         this.emitLifecycle({
@@ -792,6 +800,10 @@ export class DragEventHandler {
         if (!this.committedRangeSelection) return;
         this.committedRangeSelection = null;
         this.rangeVisual.clear();
+        // Restore normal handle visibility
+        if (this.deps.clearHiddenRangesForSelection) {
+            this.deps.clearHiddenRangesForSelection();
+        }
     }
 
     private getCommittedSelectionBlock(): BlockInfo | null {

--- a/src/editor/interaction/DragEventHandler.ts
+++ b/src/editor/interaction/DragEventHandler.ts
@@ -387,6 +387,7 @@ export class DragEventHandler {
             currentLineNumber: anchorEndLineNumber,
             committedRangesSnapshot,
             selectionRanges: initialRanges,
+            showLinks: true,
         } };
         this.pointer.attachPointerListeners();
         this.emitLifecycle({
@@ -465,6 +466,7 @@ export class DragEventHandler {
                 currentLineNumber: anchorEndLineNumber,
                 committedRangesSnapshot: [],
                 selectionRanges: precomputedRanges,
+                showLinks: false,
             },
         };
 
@@ -781,7 +783,7 @@ export class DragEventHandler {
             selectedBlock: committedBlock,
             ranges: committedRanges,
         };
-        this.rangeVisual.render(committedRanges);
+        this.rangeVisual.render(committedRanges, state.showLinks);
     }
 
     private clearCommittedRangeSelection(): void {

--- a/src/editor/interaction/RangeSelectionLogic.ts
+++ b/src/editor/interaction/RangeSelectionLogic.ts
@@ -44,6 +44,7 @@ export type MouseRangeSelectState = {
     committedRangesSnapshot: LineRange[];
     selectionRanges: LineRange[];
     showLinks: boolean;
+    highlightHandles: boolean;
 };
 
 export function normalizeLineRange(docLines: number, startLineNumber: number, endLineNumber: number): LineRange {

--- a/src/editor/interaction/RangeSelectionLogic.ts
+++ b/src/editor/interaction/RangeSelectionLogic.ts
@@ -45,6 +45,7 @@ export type MouseRangeSelectState = {
     selectionRanges: LineRange[];
     showLinks: boolean;
     highlightHandles: boolean;
+    shouldClearEditorSelectionOnCommit: boolean;
 };
 
 export function normalizeLineRange(docLines: number, startLineNumber: number, endLineNumber: number): LineRange {

--- a/src/editor/interaction/RangeSelectionLogic.ts
+++ b/src/editor/interaction/RangeSelectionLogic.ts
@@ -43,6 +43,7 @@ export type MouseRangeSelectState = {
     currentLineNumber: number;
     committedRangesSnapshot: LineRange[];
     selectionRanges: LineRange[];
+    showLinks: boolean;
 };
 
 export function normalizeLineRange(docLines: number, startLineNumber: number, endLineNumber: number): LineRange {

--- a/src/editor/interaction/SmartBlockSelector.ts
+++ b/src/editor/interaction/SmartBlockSelector.ts
@@ -1,0 +1,71 @@
+import type { EditorView } from '@codemirror/view';
+import type { BlockInfo, LineRange } from '../../types';
+import { EditorSelectionBridge } from '../core/services/EditorSelectionBridge';
+import { buildDragSourceFromLineRanges, mergeLineRanges } from './RangeSelectionLogic';
+
+export type SmartSelectionResult = {
+    shouldUseSmartSelection: boolean;
+    ranges: LineRange[];
+    blockInfo: BlockInfo | null;
+};
+
+/**
+ * SmartBlockSelector enables text-selection-to-block-selection conversion.
+ * When a user has text selected in the editor and clicks a handle within
+ * that selection, this module evaluates and returns the block-aligned
+ * selection that can be used for multi-block drag operations.
+ */
+export class SmartBlockSelector {
+    private readonly editorSelection: EditorSelectionBridge;
+
+    constructor(private readonly view: EditorView) {
+        this.editorSelection = new EditorSelectionBridge(view);
+    }
+
+    /**
+     * Evaluate whether smart block selection should be triggered based on
+     * the clicked block and current editor text selection.
+     *
+     * @param clickedBlock The block info of the handle that was clicked
+     * @returns Smart selection result with ranges and block info if applicable
+     */
+    evaluate(clickedBlock: BlockInfo): SmartSelectionResult {
+        // Convert 0-indexed to 1-indexed line number
+        const clickedStartLine = clickedBlock.startLine + 1;
+
+        // Check if the clicked block intersects with editor selection
+        const alignedRanges = this.editorSelection.getBlockAlignedRangeIfIntersecting(clickedStartLine);
+
+        if (!alignedRanges) {
+            return {
+                shouldUseSmartSelection: false,
+                ranges: [],
+                blockInfo: null,
+            };
+        }
+
+        // Merge ranges if needed
+        const docLines = this.view.state.doc.lines;
+        const mergedRanges = mergeLineRanges(docLines, alignedRanges);
+
+        // Build drag source from line ranges
+        const blockInfo = buildDragSourceFromLineRanges(
+            this.view.state.doc,
+            mergedRanges,
+            clickedBlock
+        );
+
+        return {
+            shouldUseSmartSelection: true,
+            ranges: mergedRanges,
+            blockInfo,
+        };
+    }
+
+    /**
+     * Get the underlying EditorSelectionBridge instance.
+     */
+    getEditorSelection(): EditorSelectionBridge {
+        return this.editorSelection;
+    }
+}

--- a/src/editor/interaction/SmartBlockSelector.ts
+++ b/src/editor/interaction/SmartBlockSelector.ts
@@ -1,7 +1,12 @@
 import type { EditorView } from '@codemirror/view';
 import type { BlockInfo, LineRange } from '../../types';
-import { EditorSelectionBridge } from '../core/services/EditorSelectionBridge';
-import { buildDragSourceFromLineRanges, mergeLineRanges } from './RangeSelectionLogic';
+import { EditorSelectionBridge, EditorTextSelection } from '../core/services/EditorSelectionBridge';
+import {
+    buildDragSourceFromLineRanges,
+    mergeLineRanges,
+    resolveBlockBoundaryAtLine,
+    resolveBlockAlignedLineRange,
+} from './RangeSelectionLogic';
 
 export type SmartSelectionResult = {
     shouldUseSmartSelection: boolean;
@@ -23,27 +28,42 @@ export class SmartBlockSelector {
     }
 
     /**
+     * Capture current editor selection as a snapshot.
+     * This should be called at the very start of pointerdown event,
+     * before the selection might be cleared by browser/editor.
+     */
+    captureSelectionSnapshot(): EditorTextSelection[] {
+        return this.editorSelection.getTextSelections();
+    }
+
+    /**
      * Evaluate whether smart block selection should be triggered based on
-     * the clicked block and current editor text selection.
+     * the clicked block and editor text selection.
      *
      * @param clickedBlock The block info of the handle that was clicked
+     * @param selectionSnapshot Optional pre-captured selection snapshot.
+     *                          If provided, uses this instead of reading live selection.
      * @returns Smart selection result with ranges and block info if applicable
      */
-    evaluate(clickedBlock: BlockInfo): SmartSelectionResult {
+    evaluate(clickedBlock: BlockInfo, selectionSnapshot?: EditorTextSelection[]): SmartSelectionResult {
         const clickedStartLine = clickedBlock.startLine + 1;
         const clickedEndLine = clickedBlock.endLine + 1;
 
-        // Check if the clicked block range intersects with editor selection.
-        const alignedRanges = this.editorSelection.getBlockAlignedRangeIfRangeIntersecting(
-            clickedStartLine,
-            clickedEndLine
-        );
+        // Use snapshot if provided, otherwise read live selection
+        const alignedRanges = selectionSnapshot
+            ? this.getBlockAlignedRangeFromSnapshot(selectionSnapshot, clickedStartLine, clickedEndLine)
+            : this.editorSelection.getBlockAlignedRangeIfRangeIntersecting(
+                  clickedStartLine,
+                  clickedEndLine
+              );
+
         console.log('[Dragger Debug] SmartBlockSelector.evaluate', {
             clickedBlock: {
                 startLine: clickedBlock.startLine,
                 endLine: clickedBlock.endLine,
             },
             alignedRanges,
+            usedSnapshot: !!selectionSnapshot,
         });
 
         if (!alignedRanges) {
@@ -78,6 +98,64 @@ export class SmartBlockSelector {
             ranges: mergedRanges,
             blockInfo,
         };
+    }
+
+    /**
+     * Get block-aligned ranges from a pre-captured selection snapshot.
+     */
+    private getBlockAlignedRangeFromSnapshot(
+        snapshot: EditorTextSelection[],
+        clickedStartLine: number,
+        clickedEndLine: number
+    ): LineRange[] | null {
+        if (snapshot.length === 0) return null;
+
+        const safeStart = Math.min(clickedStartLine, clickedEndLine);
+        const safeEnd = Math.max(clickedStartLine, clickedEndLine);
+
+        // Check if clicked range intersects with any selection in snapshot
+        const intersects = snapshot.some((selection) => (
+            safeEnd >= selection.fromLine && safeStart <= selection.toLine
+        ));
+
+        console.log('[Dragger Debug] SmartBlockSelector.getFromSnapshot', {
+            snapshot: snapshot.map(s => ({ fromLine: s.fromLine, toLine: s.toLine })),
+            clickedRange: { start: safeStart, end: safeEnd },
+            intersects,
+        });
+
+        if (!intersects) return null;
+
+        // Resolve block-aligned selection from snapshot
+        return this.resolveBlockAlignedSelectionFromSnapshot(snapshot);
+    }
+
+    /**
+     * Resolve block-aligned selection from a pre-captured snapshot.
+     */
+    private resolveBlockAlignedSelectionFromSnapshot(snapshot: EditorTextSelection[]): LineRange[] | null {
+        const state = this.view.state;
+        const docLines = state.doc.lines;
+        const ranges: LineRange[] = [];
+
+        for (const selection of snapshot) {
+            const startBoundary = resolveBlockBoundaryAtLine(state, selection.fromLine);
+            const endBoundary = resolveBlockBoundaryAtLine(state, selection.toLine);
+
+            const aligned = resolveBlockAlignedLineRange(
+                state,
+                startBoundary.startLineNumber,
+                startBoundary.endLineNumber,
+                endBoundary.startLineNumber,
+                endBoundary.endLineNumber
+            );
+            ranges.push({
+                startLineNumber: aligned.startLineNumber,
+                endLineNumber: aligned.endLineNumber,
+            });
+        }
+
+        return mergeLineRanges(docLines, ranges);
     }
 
     /**

--- a/src/editor/interaction/SmartBlockSelector.ts
+++ b/src/editor/interaction/SmartBlockSelector.ts
@@ -14,6 +14,8 @@ export type SmartSelectionResult = {
     blockInfo: BlockInfo | null;
 };
 
+export type { EditorTextSelection };
+
 /**
  * SmartBlockSelector enables text-selection-to-block-selection conversion.
  * When a user has text selected in the editor and clicks a handle within

--- a/src/editor/interaction/SmartBlockSelector.ts
+++ b/src/editor/interaction/SmartBlockSelector.ts
@@ -59,15 +59,6 @@ export class SmartBlockSelector {
                   clickedEndLine
               );
 
-        console.log('[Dragger Debug] SmartBlockSelector.evaluate', {
-            clickedBlock: {
-                startLine: clickedBlock.startLine,
-                endLine: clickedBlock.endLine,
-            },
-            alignedRanges,
-            usedSnapshot: !!selectionSnapshot,
-        });
-
         if (!alignedRanges) {
             return {
                 shouldUseSmartSelection: false,
@@ -86,15 +77,6 @@ export class SmartBlockSelector {
             mergedRanges,
             clickedBlock
         );
-        console.log('[Dragger Debug] SmartBlockSelector.result', {
-            mergedRanges,
-            sourceBlock: {
-                startLine: blockInfo.startLine,
-                endLine: blockInfo.endLine,
-                hasComposite: !!blockInfo.compositeSelection,
-            },
-        });
-
         return {
             shouldUseSmartSelection: true,
             ranges: mergedRanges,
@@ -119,12 +101,6 @@ export class SmartBlockSelector {
         const intersects = snapshot.some((selection) => (
             safeEnd >= selection.fromLine && safeStart <= selection.toLine
         ));
-
-        console.log('[Dragger Debug] SmartBlockSelector.getFromSnapshot', {
-            snapshot: snapshot.map(s => ({ fromLine: s.fromLine, toLine: s.toLine })),
-            clickedRange: { start: safeStart, end: safeEnd },
-            intersects,
-        });
 
         if (!intersects) return null;
 

--- a/src/editor/interaction/SmartBlockSelector.ts
+++ b/src/editor/interaction/SmartBlockSelector.ts
@@ -30,11 +30,21 @@ export class SmartBlockSelector {
      * @returns Smart selection result with ranges and block info if applicable
      */
     evaluate(clickedBlock: BlockInfo): SmartSelectionResult {
-        // Convert 0-indexed to 1-indexed line number
         const clickedStartLine = clickedBlock.startLine + 1;
+        const clickedEndLine = clickedBlock.endLine + 1;
 
-        // Check if the clicked block intersects with editor selection
-        const alignedRanges = this.editorSelection.getBlockAlignedRangeIfIntersecting(clickedStartLine);
+        // Check if the clicked block range intersects with editor selection.
+        const alignedRanges = this.editorSelection.getBlockAlignedRangeIfRangeIntersecting(
+            clickedStartLine,
+            clickedEndLine
+        );
+        console.log('[Dragger Debug] SmartBlockSelector.evaluate', {
+            clickedBlock: {
+                startLine: clickedBlock.startLine,
+                endLine: clickedBlock.endLine,
+            },
+            alignedRanges,
+        });
 
         if (!alignedRanges) {
             return {
@@ -54,6 +64,14 @@ export class SmartBlockSelector {
             mergedRanges,
             clickedBlock
         );
+        console.log('[Dragger Debug] SmartBlockSelector.result', {
+            mergedRanges,
+            sourceBlock: {
+                startLine: blockInfo.startLine,
+                endLine: blockInfo.endLine,
+                hasComposite: !!blockInfo.compositeSelection,
+            },
+        });
 
         return {
             shouldUseSmartSelection: true,

--- a/src/editor/orchestration/HandleInteractionOrchestrator.ts
+++ b/src/editor/orchestration/HandleInteractionOrchestrator.ts
@@ -153,7 +153,7 @@ export class HandleInteractionOrchestrator {
         return handle;
     }
 
-    performDropAtPoint(sourceBlock: BlockInfo, clientX: number, clientY: number, pointerType: string | null): void {
+    performDropAtPoint(sourceBlock: BlockInfo, clientX: number, clientY: number, pointerType: string | null): number | null {
         this.ensureDragPerfSession();
         const view = this.view;
         const validation = this.dropTargetCalculator.resolveValidatedDropTarget({
@@ -175,7 +175,7 @@ export class HandleInteractionOrchestrator {
                 rejectReason: validation.reason ?? 'no_target',
                 pointerType,
             });
-            return;
+            return null;
         }
 
         const targetLineNumber = validation.targetLineNumber;
@@ -203,6 +203,7 @@ export class HandleInteractionOrchestrator {
             rejectReason: null,
             pointerType,
         });
+        return targetLineNumber;
     }
 
     resolveInteractionBlockInfo(params: {

--- a/src/editor/orchestration/HandleInteractionOrchestrator.ts
+++ b/src/editor/orchestration/HandleInteractionOrchestrator.ts
@@ -137,7 +137,7 @@ export class HandleInteractionOrchestrator {
             });
             const shouldPrimePointerVisual = !(
                 e.pointerType === 'mouse'
-                && !this.isMultiLineSelectionEnabled()
+                && this.isMultiLineSelectionEnabled()
             );
             if (shouldPrimePointerVisual) {
                 const blockInfo = resolveCurrentBlock();

--- a/src/editor/orchestration/HandleInteractionOrchestrator.ts
+++ b/src/editor/orchestration/HandleInteractionOrchestrator.ts
@@ -65,7 +65,9 @@ export class HandleInteractionOrchestrator {
                     clientY: e.clientY,
                     fallback: getBlockInfo,
                 });
-                const sourceBlock = resolveCurrentBlock();
+                const sourceBlock = this.getDragEventHandler().resolveNativeDragSourceForHandleDrag(
+                    resolveCurrentBlock()
+                );
                 if (sourceBlock) {
                     this.handleVisibility.enterGrabVisualState(
                         sourceBlock.startLine + 1,
@@ -75,7 +77,8 @@ export class HandleInteractionOrchestrator {
                 } else {
                     this.handleVisibility.setActiveVisibleHandle(el);
                 }
-                const started = startDragFromHandle(e, this.view, () => resolveCurrentBlock(), el);
+                this.getDragEventHandler().finalizeNativeHandleDragStart();
+                const started = startDragFromHandle(e, this.view, () => sourceBlock, el);
                 if (!started) {
                     this.handleVisibility.setActiveVisibleHandle(null);
                     finishDragSession(this.view);

--- a/src/editor/visual/HandleVisibilityController.spec.ts
+++ b/src/editor/visual/HandleVisibilityController.spec.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { EditorState } from '@codemirror/state';
+import type { EditorView } from '@codemirror/view';
+import { describe, expect, it } from 'vitest';
+import { HandleVisibilityController } from './HandleVisibilityController';
+
+function createViewStub(lineCount: number): EditorView {
+    const root = document.createElement('div');
+    const content = document.createElement('div');
+    root.appendChild(content);
+    document.body.appendChild(root);
+
+    const state = EditorState.create({
+        doc: Array.from({ length: lineCount }, (_, i) => `line ${i + 1}`).join('\n'),
+    });
+
+    const lineElements: HTMLElement[] = [];
+    for (let i = 0; i < lineCount; i++) {
+        const lineEl = document.createElement('div');
+        lineEl.className = 'cm-line';
+        lineEl.textContent = `line ${i + 1}`;
+        content.appendChild(lineEl);
+        lineElements.push(lineEl);
+    }
+
+    return {
+        dom: root,
+        contentDOM: content,
+        state,
+        domAtPos: (pos: number) => {
+            const line = state.doc.lineAt(pos);
+            const node = lineElements[Math.max(0, line.number - 1)] ?? content;
+            return { node, offset: 0 };
+        },
+    } as unknown as EditorView;
+}
+
+describe('HandleVisibilityController', () => {
+    it('clears selection highlight when grabbed line numbers are cleared', () => {
+        const view = createViewStub(5);
+        const controller = new HandleVisibilityController(view, {
+            getBlockInfoForHandle: () => null,
+            getDraggableBlockAtPoint: () => null,
+        });
+
+        controller.enterGrabVisualState(2, 4, null);
+
+        expect(view.dom.querySelectorAll('.dnd-selection-highlight-line').length).toBe(3);
+
+        controller.clearGrabbedLineNumbers();
+
+        expect(view.dom.querySelectorAll('.dnd-selection-highlight-line').length).toBe(0);
+    });
+});

--- a/src/editor/visual/HandleVisibilityController.spec.ts
+++ b/src/editor/visual/HandleVisibilityController.spec.ts
@@ -4,6 +4,7 @@ import { EditorState } from '@codemirror/state';
 import type { EditorView } from '@codemirror/view';
 import { describe, expect, it } from 'vitest';
 import { HandleVisibilityController } from './HandleVisibilityController';
+import { BLOCK_SELECTION_ACTIVE_CLASS } from '../core/constants';
 
 function createViewStub(lineCount: number): EditorView {
     const root = document.createElement('div');
@@ -51,5 +52,55 @@ describe('HandleVisibilityController', () => {
         controller.clearGrabbedLineNumbers();
 
         expect(view.dom.querySelectorAll('.dnd-selection-highlight-line').length).toBe(0);
+    });
+
+    it('keeps only anchor handle visible while block selection is active', () => {
+        const view = createViewStub(6);
+        const controller = new HandleVisibilityController(view, {
+            getBlockInfoForHandle: () => null,
+            getDraggableBlockAtPoint: () => null,
+        });
+
+        const anchorHandle = document.createElement('div');
+        anchorHandle.className = 'dnd-drag-handle';
+        anchorHandle.setAttribute('data-block-start', '2');
+        const otherHandle = document.createElement('div');
+        otherHandle.className = 'dnd-drag-handle';
+        otherHandle.setAttribute('data-block-start', '4');
+        view.dom.appendChild(anchorHandle);
+        view.dom.appendChild(otherHandle);
+
+        controller.setHiddenRangesForSelection([{ startLineNumber: 3, endLineNumber: 3 }], anchorHandle);
+
+        expect(document.body.classList.contains(BLOCK_SELECTION_ACTIVE_CLASS)).toBe(true);
+        expect(anchorHandle.classList.contains('dnd-selection-anchor-handle')).toBe(true);
+        expect(anchorHandle.classList.contains('dnd-selection-handle-hidden')).toBe(false);
+        expect(otherHandle.classList.contains('dnd-selection-handle-hidden')).toBe(true);
+    });
+
+    it('restores handle visibility classes after block selection is cleared', () => {
+        const view = createViewStub(6);
+        const controller = new HandleVisibilityController(view, {
+            getBlockInfoForHandle: () => null,
+            getDraggableBlockAtPoint: () => null,
+        });
+
+        const anchorHandle = document.createElement('div');
+        anchorHandle.className = 'dnd-drag-handle';
+        anchorHandle.setAttribute('data-block-start', '1');
+        const otherHandle = document.createElement('div');
+        otherHandle.className = 'dnd-drag-handle';
+        otherHandle.setAttribute('data-block-start', '3');
+        view.dom.appendChild(anchorHandle);
+        view.dom.appendChild(otherHandle);
+
+        controller.setHiddenRangesForSelection([{ startLineNumber: 2, endLineNumber: 2 }], anchorHandle);
+        controller.clearHiddenRangesForSelection();
+
+        expect(document.body.classList.contains(BLOCK_SELECTION_ACTIVE_CLASS)).toBe(false);
+        expect(anchorHandle.classList.contains('dnd-selection-anchor-handle')).toBe(false);
+        expect(anchorHandle.classList.contains('dnd-selection-handle-hidden')).toBe(false);
+        expect(otherHandle.classList.contains('dnd-selection-anchor-handle')).toBe(false);
+        expect(otherHandle.classList.contains('dnd-selection-handle-hidden')).toBe(false);
     });
 });

--- a/src/editor/visual/HandleVisibilityController.ts
+++ b/src/editor/visual/HandleVisibilityController.ts
@@ -50,6 +50,8 @@ export class HandleVisibilityController {
             lineNumberEl.classList.remove(GRAB_HIDDEN_LINE_NUMBER_CLASS);
         }
         this.hiddenGrabbedLineNumberEls.clear();
+        // Grab highlight is tied to an active drag gesture and must not persist after cleanup.
+        this.selectionHighlight.clear();
     }
 
     setGrabbedLineNumberRange(startLineNumber: number, endLineNumber: number): void {

--- a/src/editor/visual/HandleVisibilityController.ts
+++ b/src/editor/visual/HandleVisibilityController.ts
@@ -5,6 +5,7 @@ import {
     hasVisibleLineNumberGutter,
 } from '../core/handle-position';
 import { DRAG_HANDLE_CLASS } from '../core/selectors';
+import { SelectionHighlightManager } from './HoverHighlightManager';
 import {
     HANDLE_INTERACTION_ZONE_PX,
     HOVER_HIDDEN_LINE_NUMBER_CLASS,
@@ -21,6 +22,7 @@ export class HandleVisibilityController {
     private currentHoveredLineNumber: number | null = null;
     private readonly hiddenGrabbedLineNumberEls = new Set<HTMLElement>();
     private activeHandle: HTMLElement | null = null;
+    private readonly selectionHighlight = new SelectionHighlightManager();
 
     constructor(
         private readonly view: EditorView,
@@ -106,6 +108,15 @@ export class HandleVisibilityController {
         );
         this.clearHoveredLineNumber();
         this.setGrabbedLineNumberRange(startLineNumber, endLineNumber);
+        this.selectionHighlight.highlight(this.view, startLineNumber, endLineNumber);
+    }
+
+    clearSelectionHighlight(): void {
+        this.selectionHighlight.clear();
+    }
+
+    reapplySelectionHighlight(): void {
+        this.selectionHighlight.reapply(this.view);
     }
 
     isPointerInHandleInteractionZone(clientX: number, clientY: number): boolean {

--- a/src/editor/visual/HoverHighlightManager.ts
+++ b/src/editor/visual/HoverHighlightManager.ts
@@ -1,0 +1,72 @@
+import { EditorView } from '@codemirror/view';
+import { SELECTION_HIGHLIGHT_LINE_CLASS } from '../core/selectors';
+
+/**
+ * Manages the selection highlight on `.cm-line` elements
+ * for the currently grabbed / single-block-selected range.
+ *
+ * Tracks the highlighted line range so the class can be re-applied
+ * after CM6 DOM updates (which may reset element classes).
+ */
+export class SelectionHighlightManager {
+    private readonly highlightedEls = new Set<HTMLElement>();
+    private activeRange: { start: number; end: number } | null = null;
+
+    highlight(view: EditorView, startLineNumber: number, endLineNumber: number): void {
+        this.removeClassFromElements();
+        this.activeRange = { start: startLineNumber, end: endLineNumber };
+        this.applyToDOM(view);
+    }
+
+    clear(): void {
+        this.removeClassFromElements();
+        this.activeRange = null;
+    }
+
+    /** Re-apply after CM6 view update that may have replaced DOM elements. */
+    reapply(view: EditorView): void {
+        if (!this.activeRange) return;
+        this.removeClassFromElements();
+        this.applyToDOM(view);
+    }
+
+    destroy(): void {
+        this.clear();
+    }
+
+    private applyToDOM(view: EditorView): void {
+        if (!this.activeRange) return;
+        const doc = view.state.doc;
+        const from = Math.max(1, Math.min(doc.lines, this.activeRange.start));
+        const to = Math.max(1, Math.min(doc.lines, this.activeRange.end));
+        for (let lineNumber = from; lineNumber <= to; lineNumber++) {
+            const lineEl = this.getLineElementForLine(view, lineNumber);
+            if (!lineEl) continue;
+            lineEl.classList.add(SELECTION_HIGHLIGHT_LINE_CLASS);
+            this.highlightedEls.add(lineEl);
+        }
+    }
+
+    private removeClassFromElements(): void {
+        for (const el of this.highlightedEls) {
+            el.classList.remove(SELECTION_HIGHLIGHT_LINE_CLASS);
+        }
+        this.highlightedEls.clear();
+    }
+
+    private getLineElementForLine(view: EditorView, lineNumber: number): HTMLElement | null {
+        if (lineNumber < 1 || lineNumber > view.state.doc.lines) return null;
+        if (typeof view.domAtPos !== 'function') return null;
+        try {
+            const line = view.state.doc.line(lineNumber);
+            const domAtPos = view.domAtPos(line.from);
+            const base = domAtPos.node.nodeType === Node.TEXT_NODE
+                ? domAtPos.node.parentElement
+                : domAtPos.node;
+            if (!(base instanceof Element)) return null;
+            return base.closest<HTMLElement>('.cm-line') ?? null;
+        } catch {
+            return null;
+        }
+    }
+}

--- a/src/editor/visual/RangeSelectionVisualManager.ts
+++ b/src/editor/visual/RangeSelectionVisualManager.ts
@@ -34,7 +34,7 @@ export class RangeSelectionVisualManager {
         this.bindScrollListener();
     }
 
-    render(ranges: LineRange[]): void {
+    render(ranges: LineRange[], showLinks: boolean = true): void {
         const normalizedRanges = this.mergeLineRanges(ranges);
         const nextLineElements = new Set<HTMLElement>();
         const nextLineNumberElements = new Set<HTMLElement>();
@@ -78,7 +78,11 @@ export class RangeSelectionVisualManager {
             nextHandleElements,
             RANGE_SELECTED_HANDLE_CLASS
         );
-        this.updateLinks(normalizedRanges);
+        if (showLinks) {
+            this.updateLinks(normalizedRanges);
+        } else {
+            this.hideLinks();
+        }
     }
 
     clear(): void {
@@ -97,6 +101,10 @@ export class RangeSelectionVisualManager {
         }
         this.handleElements.clear();
 
+        this.hideLinks();
+    }
+
+    private hideLinks(): void {
         for (const link of this.linkEls) {
             link.classList.remove('is-active');
         }

--- a/src/editor/visual/RangeSelectionVisualManager.ts
+++ b/src/editor/visual/RangeSelectionVisualManager.ts
@@ -41,11 +41,6 @@ export class RangeSelectionVisualManager {
     render(ranges: LineRange[], options?: { showLinks?: boolean; highlightHandles?: boolean }): void {
         const showLinks = options?.showLinks ?? true;
         const highlightHandles = options?.highlightHandles ?? true;
-        console.log('[Dragger Debug] RangeSelectionVisualManager.render', {
-            ranges: JSON.stringify(ranges),
-            showLinks,
-            highlightHandles,
-        });
         const normalizedRanges = this.mergeLineRanges(ranges);
         const nextLineElements = new Set<HTMLElement>();
         const nextLineNumberElements = new Set<HTMLElement>();
@@ -64,9 +59,6 @@ export class RangeSelectionVisualManager {
                     const lineEl = this.getLineElementForLine(lineNumber);
                     if (lineEl) {
                         nextLineElements.add(lineEl);
-                        console.log('[Dragger Debug] Found line element for line', lineNumber, ':', lineEl.className);
-                    } else {
-                        console.log('[Dragger Debug] No line element found for line', lineNumber);
                     }
                     const lineNumberEl = getLineNumberElementForLine(this.view, lineNumber);
                     if (lineNumberEl) {
@@ -82,7 +74,6 @@ export class RangeSelectionVisualManager {
                 pos = line.to + 1;
             }
         }
-        console.log('[Dragger Debug] Matched lines:', matchedLines, 'lineElements count:', nextLineElements.size);
         if (matchedLines.length > 0 && nextLineElements.size === 0) {
             this.scheduleLineResolutionRetry();
         } else {
@@ -93,10 +84,6 @@ export class RangeSelectionVisualManager {
             nextLineElements,
             RANGE_SELECTED_LINE_CLASS
         );
-        // Verify after sync
-        console.log('[Dragger Debug] After sync, checking DOM for class:', RANGE_SELECTED_LINE_CLASS);
-        const checkEls = this.view.dom.querySelectorAll('.' + RANGE_SELECTED_LINE_CLASS);
-        console.log('[Dragger Debug] DOM elements with class:', checkEls.length);
         this.syncSelectionElements(
             this.lineNumberElements,
             nextLineNumberElements,
@@ -115,10 +102,6 @@ export class RangeSelectionVisualManager {
     }
 
     clear(): void {
-        // Add stack trace to find who is calling clear
-        console.log('[Dragger Debug] RangeSelectionVisualManager.clear called, lineElements count:', this.lineElements.size);
-        console.log('[Dragger Debug] clear() stack trace:', new Error().stack);
-
         // Clear tracked elements
         for (const lineEl of this.lineElements) {
             lineEl.classList.remove(RANGE_SELECTED_LINE_CLASS);
@@ -142,8 +125,6 @@ export class RangeSelectionVisualManager {
 
         const remainingHandleElements = this.view.dom.querySelectorAll(`.${RANGE_SELECTED_HANDLE_CLASS}`);
         remainingHandleElements.forEach(el => el.classList.remove(RANGE_SELECTED_HANDLE_CLASS));
-
-        console.log('[Dragger Debug] Cleared remaining elements - lines:', remainingLineElements.length, 'handles:', remainingHandleElements.length);
 
         this.hideLinks();
         this.clearLineResolutionRetry();
@@ -271,12 +252,6 @@ export class RangeSelectionVisualManager {
         next: Set<HTMLElement>,
         className: string
     ): void {
-        console.log('[Dragger Debug] syncSelectionElements', {
-            className,
-            currentSize: current.size,
-            nextSize: next.size,
-        });
-
         // Remove class from elements that are no longer selected
         // Use a direct DOM check instead of relying on Set identity
         for (const el of current) {
@@ -286,15 +261,12 @@ export class RangeSelectionVisualManager {
         }
 
         // Add class to all elements in next set (they should all have the class)
-        let addedCount = 0;
         for (const el of next) {
             if (!el.isConnected) continue;
             if (!el.classList.contains(className)) {
                 el.classList.add(className);
-                addedCount++;
             }
         }
-        console.log('[Dragger Debug] syncSelectionElements added', addedCount, 'classes');
 
         current.clear();
         for (const el of next) {

--- a/src/editor/visual/RangeSelectionVisualManager.ts
+++ b/src/editor/visual/RangeSelectionVisualManager.ts
@@ -60,6 +60,9 @@ export class RangeSelectionVisualManager {
                     const lineEl = this.getLineElementForLine(lineNumber);
                     if (lineEl) {
                         nextLineElements.add(lineEl);
+                        console.log('[Dragger Debug] Found line element for line', lineNumber, ':', lineEl.className);
+                    } else {
+                        console.log('[Dragger Debug] No line element found for line', lineNumber);
                     }
                     const lineNumberEl = getLineNumberElementForLine(this.view, lineNumber);
                     if (lineNumberEl) {
@@ -81,6 +84,10 @@ export class RangeSelectionVisualManager {
             nextLineElements,
             RANGE_SELECTED_LINE_CLASS
         );
+        // Verify after sync
+        console.log('[Dragger Debug] After sync, checking DOM for class:', RANGE_SELECTED_LINE_CLASS);
+        const checkEls = this.view.dom.querySelectorAll('.' + RANGE_SELECTED_LINE_CLASS);
+        console.log('[Dragger Debug] DOM elements with class:', checkEls.length);
         this.syncSelectionElements(
             this.lineNumberElements,
             nextLineNumberElements,
@@ -243,14 +250,30 @@ export class RangeSelectionVisualManager {
         next: Set<HTMLElement>,
         className: string
     ): void {
+        console.log('[Dragger Debug] syncSelectionElements', {
+            className,
+            currentSize: current.size,
+            nextSize: next.size,
+        });
+
+        // Remove class from elements that are no longer selected
+        // Use a direct DOM check instead of relying on Set identity
         for (const el of current) {
-            if (next.has(el)) continue;
-            el.classList.remove(className);
+            if (!next.has(el) && el.isConnected) {
+                el.classList.remove(className);
+            }
         }
+
+        // Add class to all elements in next set (they should all have the class)
+        let addedCount = 0;
         for (const el of next) {
-            if (current.has(el)) continue;
-            el.classList.add(className);
+            if (!el.classList.contains(className)) {
+                el.classList.add(className);
+                addedCount++;
+            }
         }
+        console.log('[Dragger Debug] syncSelectionElements added', addedCount, 'classes');
+
         current.clear();
         for (const el of next) {
             current.add(el);

--- a/src/editor/visual/RangeSelectionVisualManager.ts
+++ b/src/editor/visual/RangeSelectionVisualManager.ts
@@ -34,7 +34,9 @@ export class RangeSelectionVisualManager {
         this.bindScrollListener();
     }
 
-    render(ranges: LineRange[], showLinks: boolean = true): void {
+    render(ranges: LineRange[], options?: { showLinks?: boolean; highlightHandles?: boolean }): void {
+        const showLinks = options?.showLinks ?? true;
+        const highlightHandles = options?.highlightHandles ?? true;
         const normalizedRanges = this.mergeLineRanges(ranges);
         const nextLineElements = new Set<HTMLElement>();
         const nextLineNumberElements = new Set<HTMLElement>();
@@ -55,9 +57,11 @@ export class RangeSelectionVisualManager {
                     if (lineNumberEl) {
                         nextLineNumberElements.add(lineNumberEl);
                     }
-                    const handleEl = this.getInlineHandleForLine(lineNumber);
-                    if (handleEl) {
-                        nextHandleElements.add(handleEl);
+                    if (highlightHandles) {
+                        const handleEl = this.getInlineHandleForLine(lineNumber);
+                        if (handleEl) {
+                            nextHandleElements.add(handleEl);
+                        }
                     }
                 }
                 pos = line.to + 1;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -34,6 +34,10 @@ const zh = {
     handleOffset: '手柄横向位置',
     handleOffsetDesc: '向左为负值，向右为正值',
 
+    // Selection highlight color
+    selectionHighlightColor: '选中高亮颜色',
+    selectionHighlightColorDesc: '选中块时行背景光晕的颜色',
+
     // Indicator color
     indicatorColor: '指示器颜色',
     indicatorColorDesc: '跟随主题强调色或自定义颜色',
@@ -74,6 +78,9 @@ const en: typeof zh = {
 
     handleOffset: 'Handle horizontal offset',
     handleOffsetDesc: 'Negative = left, positive = right',
+
+    selectionHighlightColor: 'Selection highlight color',
+    selectionHighlightColorDesc: 'Background glow color on selected blocks',
 
     indicatorColor: 'Indicator color',
     indicatorColorDesc: 'Follow theme accent or pick a custom color',

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,6 +72,19 @@ export default class DragNDropPlugin extends Plugin {
             body.style.removeProperty('--dnd-handle-color-hover');
         }
 
+        let selectionHighlightColorValue = '';
+        if (this.settings.selectionHighlightColorMode === 'theme') {
+            selectionHighlightColorValue = 'var(--interactive-accent)';
+        } else if (this.settings.selectionHighlightColor) {
+            selectionHighlightColorValue = this.settings.selectionHighlightColor;
+        }
+
+        if (selectionHighlightColorValue) {
+            body.style.setProperty('--dnd-selection-highlight-color', selectionHighlightColorValue);
+        } else {
+            body.style.removeProperty('--dnd-selection-highlight-color');
+        }
+
         let indicatorColorValue = '';
         if (this.settings.indicatorColorMode === 'theme') {
             indicatorColorValue = 'var(--interactive-accent)';

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,10 +85,10 @@ export default class DragNDropPlugin extends Plugin {
             body.style.removeProperty('--dnd-drop-indicator-color');
         }
 
-        const handleSize = Math.max(12, Math.min(28, this.settings.handleSize ?? 16));
+        const handleSize = Math.max(12, Math.min(36, this.settings.handleSize ?? 24));
         setHandleSizePx(handleSize);
         body.style.setProperty('--dnd-handle-size', `${handleSize}px`);
-        body.style.setProperty('--dnd-handle-core-size', `${Math.round(handleSize * 0.5)}px`);
+        body.style.setProperty('--dnd-handle-core-size', `${Math.round(handleSize * 0.65)}px`);
         body.setAttribute('data-dnd-handle-icon', this.settings.handleIcon ?? 'dot');
 
         window.dispatchEvent(new Event('dnd:settings-updated'));

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,7 @@ export default class DragNDropPlugin extends Plugin {
 
         let colorValue = '';
         if (this.settings.handleColorMode === 'theme') {
-            colorValue = 'var(--interactive-accent)';
+            colorValue = 'var(--text-normal)';
         } else if (this.settings.handleColor) {
             colorValue = this.settings.handleColor;
         }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -35,7 +35,7 @@ export const DEFAULT_SETTINGS: DragNDropSettings = {
     handleColor: '#8a8a8a',
     handleVisibility: 'hover',
     handleIcon: 'dot',
-    handleSize: 16,
+    handleSize: 24,
     indicatorColorMode: 'theme',
     indicatorColor: '#7a7a7a',
     enableCrossFileDrag: false,
@@ -110,7 +110,7 @@ export class DragNDropSettingTab extends PluginSettingTab {
             .setName(i.handleSize)
             .setDesc(i.handleSizeDesc)
             .addSlider((slider) => slider
-                .setLimits(12, 28, 2)
+                .setLimits(12, 36, 2)
                 .setDynamicTooltip()
                 .setValue(this.plugin.settings.handleSize)
                 .onChange(async (value) => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -24,6 +24,10 @@ export interface DragNDropSettings {
     enableCrossFileDrag: boolean;
     // 是否启用多行选取拖拽
     enableMultiLineSelection: boolean;
+    // 选中高亮颜色模式
+    selectionHighlightColorMode: 'theme' | 'custom';
+    // 选中高亮颜色（自定义时生效）
+    selectionHighlightColor: string;
     // 手柄横向偏移量（像素）
     handleHorizontalOffsetPx: number;
     // 手柄是否与行号对齐
@@ -38,6 +42,8 @@ export const DEFAULT_SETTINGS: DragNDropSettings = {
     handleSize: 24,
     indicatorColorMode: 'theme',
     indicatorColor: '#7a7a7a',
+    selectionHighlightColorMode: 'theme',
+    selectionHighlightColor: '#4f9eff',
     enableCrossFileDrag: false,
     enableMultiLineSelection: true,
     handleHorizontalOffsetPx: 0,
@@ -139,6 +145,26 @@ export class DragNDropSettingTab extends PluginSettingTab {
                     this.plugin.settings.alignHandleToLineNumber = value;
                     await this.plugin.saveSettings();
                 }));
+
+        const selectionHighlightSetting = new Setting(containerEl)
+            .setName(i.selectionHighlightColor)
+            .setDesc(i.selectionHighlightColorDesc);
+
+        selectionHighlightSetting.addDropdown(dropdown => dropdown
+            .addOption('theme', i.optionTheme)
+            .addOption('custom', i.optionCustom)
+            .setValue(this.plugin.settings.selectionHighlightColorMode)
+            .onChange(async (value: 'theme' | 'custom') => {
+                this.plugin.settings.selectionHighlightColorMode = value;
+                await this.plugin.saveSettings();
+            }));
+
+        selectionHighlightSetting.addColorPicker(picker => picker
+            .setValue(this.plugin.settings.selectionHighlightColor)
+            .onChange(async (value) => {
+                this.plugin.settings.selectionHighlightColor = value;
+                await this.plugin.saveSettings();
+            }));
 
         const indicatorSetting = new Setting(containerEl)
             .setName(i.indicatorColor)

--- a/styles.css
+++ b/styles.css
@@ -236,7 +236,7 @@ body.dnd-mobile-gesture-lock {
     pointer-events: none;
     z-index: 9999;
     border-radius: 6px;
-    background: color-mix(in srgb, var(--dnd-drop-highlight-color, var(--interactive-accent)) 14%, transparent);
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--dnd-drop-highlight-color, var(--interactive-accent)) 36%, transparent);
+    background: color-mix(in srgb, var(--dnd-drop-indicator-color, var(--interactive-accent)) 14%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--dnd-drop-indicator-color, var(--interactive-accent)) 36%, transparent);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -130,10 +130,10 @@ body:not(.dnd-block-selection-active) .dnd-drag-handle:hover {
     width: 3px;
     transform: translateX(-50%);
     border-radius: 999px;
-    /* Use selection color, not handle color, to avoid "black sidebar" in light themes
-       where handle color defaults to --text-normal. */
-    background-color: var(--dnd-selection-highlight-color, var(--interactive-accent));
-    box-shadow: 0 0 4px color-mix(in srgb, var(--dnd-selection-highlight-color, var(--interactive-accent)) 28%, transparent);
+    /* Use a more reliable color fallback chain to avoid "black sidebar" in light themes.
+       Fallback order: custom var -> text-accent -> interactive-accent -> explicit purple */
+    background-color: var(--dnd-selection-highlight-color, var(--text-accent, var(--interactive-accent, #7c3aed)));
+    box-shadow: 0 0 4px color-mix(in srgb, var(--dnd-selection-highlight-color, var(--text-accent, var(--interactive-accent, #7c3aed))) 28%, transparent);
     will-change: left, top, height, opacity;
     transition:
         left 45ms linear,

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,12 @@
     border-radius: 2px;
 }
 
+/* 选中高亮：单块拖拽时对应行的背景光晕 */
+.cm-line.dnd-selection-highlight-line {
+    background: color-mix(in srgb, var(--dnd-selection-highlight-color, var(--interactive-accent)) 12%, transparent);
+    border-radius: 4px;
+}
+
 /* 所有块共用同一显示态：由统一事件链添加 is-visible */
 .dnd-drag-handle.is-visible {
     opacity: 0.5;
@@ -113,8 +119,8 @@
         0 0 10px color-mix(in srgb, var(--dnd-handle-color, var(--interactive-accent)) 45%, transparent);
 }
 
-.markdown-source-view.mod-cm6 .cm-editor.dnd-root-editor .cm-content.dnd-main-content > .cm-line.dnd-range-selected-line {
-    background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
+.cm-line.dnd-range-selected-line {
+    background: color-mix(in srgb, var(--dnd-selection-highlight-color, var(--interactive-accent)) 14%, transparent);
     border-radius: 4px;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -127,11 +127,13 @@ body:not(.dnd-block-selection-active) .dnd-drag-handle:hover {
 
 .dnd-range-selection-link {
     position: absolute;
-    width: 4px;
+    width: 3px;
     transform: translateX(-50%);
     border-radius: 999px;
-    background-color: var(--dnd-handle-color, var(--interactive-accent));
-    box-shadow: 0 0 6px color-mix(in srgb, var(--dnd-handle-color, var(--interactive-accent)) 36%, transparent);
+    /* Use selection color, not handle color, to avoid "black sidebar" in light themes
+       where handle color defaults to --text-normal. */
+    background-color: var(--dnd-selection-highlight-color, var(--interactive-accent));
+    box-shadow: 0 0 4px color-mix(in srgb, var(--dnd-selection-highlight-color, var(--interactive-accent)) 28%, transparent);
     will-change: left, top, height, opacity;
     transition:
         left 45ms linear,
@@ -240,4 +242,3 @@ body.dnd-mobile-gesture-lock {
     background: color-mix(in srgb, var(--dnd-drop-indicator-color, var(--interactive-accent)) 14%, transparent);
     box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--dnd-drop-indicator-color, var(--interactive-accent)) 36%, transparent);
 }
-

--- a/styles.css
+++ b/styles.css
@@ -7,11 +7,11 @@
 /* 拖拽手柄 - 完全悬浮定位，不影响文档布局 */
 .dnd-drag-handle {
     position: absolute;
-    left: -16px;
+    left: calc(-1 * var(--dnd-handle-size, 24px));
     top: 0;
     transform: none;
-    width: var(--dnd-handle-size, 16px);
-    height: var(--dnd-handle-size, 16px);
+    width: var(--dnd-handle-size, 24px);
+    height: var(--dnd-handle-size, 24px);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -34,8 +34,8 @@
 }
 
 .dnd-handle-core {
-    width: var(--dnd-handle-core-size, 8px);
-    height: var(--dnd-handle-core-size, 8px);
+    width: var(--dnd-handle-core-size, 16px);
+    height: var(--dnd-handle-core-size, 16px);
     border-radius: 999px;
     background: currentColor;
     box-shadow:
@@ -50,7 +50,7 @@
     border-radius: 0;
     background: none;
     box-shadow: none;
-    font-size: var(--dnd-handle-core-size, 8px);
+    font-size: var(--dnd-handle-core-size, 16px);
     line-height: 1;
 }
 [data-dnd-handle-icon="grip-dots"] .dnd-handle-core::before {
@@ -64,7 +64,7 @@
     border-radius: 0;
     background: none;
     box-shadow: none;
-    font-size: var(--dnd-handle-core-size, 8px);
+    font-size: var(--dnd-handle-core-size, 16px);
     line-height: 1;
 }
 [data-dnd-handle-icon="grip-lines"] .dnd-handle-core::before {

--- a/styles.css
+++ b/styles.css
@@ -23,7 +23,8 @@
     z-index: 1;
 }
 
-.dnd-drag-handle:hover {
+/* Disable hover state when block selection is active - only anchor handle should be visible */
+body:not(.dnd-block-selection-active) .dnd-drag-handle:hover {
     opacity: 1 !important;
     color: var(--dnd-handle-color-hover, var(--dnd-handle-color, var(--text-accent)));
     filter: brightness(1.08);

--- a/styles.css
+++ b/styles.css
@@ -120,6 +120,16 @@ body:not(.dnd-block-selection-active) .dnd-drag-handle:hover {
         0 0 10px color-mix(in srgb, var(--dnd-handle-color, var(--interactive-accent)) 45%, transparent);
 }
 
+body.dnd-block-selection-active .dnd-drag-handle.dnd-selection-handle-hidden {
+    opacity: 0 !important;
+    pointer-events: none !important;
+}
+
+body.dnd-block-selection-active .dnd-drag-handle.dnd-selection-anchor-handle {
+    opacity: 1 !important;
+    pointer-events: auto !important;
+}
+
 .cm-line.dnd-range-selected-line {
     background: color-mix(in srgb, var(--dnd-selection-highlight-color, var(--interactive-accent)) 14%, transparent);
     border-radius: 4px;


### PR DESCRIPTION
**标题**
`feat: 智能文本选区块拖拽 + 选中态稳定恢复 + 交互与日志清理`

**描述**
```markdown
## 变更概述

这个 PR 完整实现了“文本选区 -> 块选中 -> 直接拖拽”的工作流，并修复了选中态在点击、拖拽、放下、刷新过程中的稳定性问题；同时补齐了多段选区恢复逻辑，最后清理了运行时调试日志。

## 主要改动

1. 智能选区转块选区
- 新增 `EditorSelectionBridge` 与 `SmartBlockSelector`。
- 当用户已选中文字并点击对应手柄时，将文本选区对齐为块级范围并进入块拖拽链路。

2. 拖拽与选中流程稳定化
- 鼠标快速点击可提交块选中（不必依赖二次长按）。
- 保留 smart selection 后直接原生 HTML5 拖拽能力。
- 优化鼠标/触摸在 long-press、move threshold、状态切换上的一致性。

3. drop 后恢复选中逻辑加固
- 修复恢复时 source block 元信息漂移（不再硬编码成 paragraph）。
- 保留并恢复 range span，避免多段选区被错误压扁。
- 恢复后的 `selectedBlock` 与后续拖拽语义保持一致。

4. 生命周期与边界问题修复
- 修复 `_pendingSelectionSnapshot` 旧快照复用导致的污染问题。
- 收紧 pointerdown 清理 guard，降低“误清/漏清”概率。
- 修复视图刷新后 committed selection 被意外清空的问题。
- 支持点击选中块阴影区域即可取消选中。

5. 视觉与交互优化
- 选中时隐藏非锚点块手柄。
- 统一 handle hover/selected 行为，避免选中态期间视觉跳变。
- 调整拖拽手柄可见性与命中体验。
- 样式侧补充选中背景高亮与相关细节修正。

6. 调试日志清理
- 移除运行时 `[Dragger Debug]` 与相关 `console.log/debug` 输出。
- 将性能日志函数在常规运行路径下改为 no-op，避免噪音。

## 测试与验证

1. 类型检查通过：`npm run -s typecheck`
2. 全量测试通过：`npm test`（19 files / 130 tests）
3. 本次覆盖了 smart selection、单块/多块、drop restore、pointer guard、native drag 等关键路径。

## 说明

这是同一功能链路上的连续迭代提交（功能实现 + 稳定性修复 + 日志清理），建议按最终行为整体评审。
```