### PR TITLE
Add linked note and sidebar drop targets

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -4,7 +4,9 @@ import builtins from "builtin-modules";
 import fs from "fs";
 
 const prod = process.argv[2] === "production";
-const pluginDir = "V:/dragger/.obsidian/plugins/dragger";
+const pluginDir = process.env.OBSIDIAN_PLUGIN_DIR || "V:/dragger/.obsidian/plugins/dragger";
+
+fs.mkdirSync(pluginDir, { recursive: true });
 
 // 复制 styles.css 到插件目录
 function copyStyles() {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "main": "main.js",
     "scripts": {
         "dev": "node esbuild.config.mjs",
+        "dev:thoughts": "OBSIDIAN_PLUGIN_DIR=/Users/flo/Documents/Development/Thoughts/.obsidian/plugins/dragger node esbuild.config.mjs",
         "build": "node esbuild.config.mjs production",
+        "build:thoughts": "OBSIDIAN_PLUGIN_DIR=/Users/flo/Documents/Development/Thoughts/.obsidian/plugins/dragger node esbuild.config.mjs production",
         "lint": "eslint src --config eslint.config.mjs",
         "lint:fix": "eslint src --config eslint.config.mjs --fix",
         "lint:review": "eslint src --config eslint.config.mjs --max-warnings=0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
     "main": "main.js",
     "scripts": {
         "dev": "node esbuild.config.mjs",
-        "dev:thoughts": "OBSIDIAN_PLUGIN_DIR=/Users/flo/Documents/Development/Thoughts/.obsidian/plugins/dragger node esbuild.config.mjs",
         "build": "node esbuild.config.mjs production",
-        "build:thoughts": "OBSIDIAN_PLUGIN_DIR=/Users/flo/Documents/Development/Thoughts/.obsidian/plugins/dragger node esbuild.config.mjs production",
         "lint": "eslint src --config eslint.config.mjs",
         "lint:fix": "eslint src --config eslint.config.mjs --fix",
         "lint:review": "eslint src --config eslint.config.mjs --max-warnings=0",

--- a/src/features/entry/external-file-drop-controller.ts
+++ b/src/features/entry/external-file-drop-controller.ts
@@ -141,9 +141,11 @@ export class ExternalFileDropController {
             return contextPath ? this.resolveMarkdownFileByVaultPath(contextPath) : null;
         }
 
-        const resolved = this.plugin.app.metadataCache.getFirstLinkpathDest(rawLinkpath, contextPath ?? '');
+        const cleanLinkpath = stripSubpath(rawLinkpath);
+        if (!cleanLinkpath) return null;
+        const resolved = this.plugin.app.metadataCache.getFirstLinkpathDest(cleanLinkpath, contextPath ?? '');
         if (isMarkdownFile(resolved)) return resolved;
-        return this.resolveMarkdownFileByVaultPath(stripSubpath(rawLinkpath));
+        return this.resolveMarkdownFileByVaultPath(cleanLinkpath);
     }
 
     private getInternalLinkPath(element: HTMLElement): string | null {
@@ -188,7 +190,7 @@ export class ExternalFileDropController {
 
         for (const candidate of candidates) {
             const normalized = normalizePath(candidate);
-            const file = this.plugin.app.vault.getFileByPath(normalized)
+            const file = this.plugin.app.vault.getFileByPath?.(normalized)
                 ?? this.plugin.app.vault.getAbstractFileByPath(normalized);
             if (isMarkdownFile(file)) return file;
         }

--- a/src/features/entry/external-file-drop-controller.ts
+++ b/src/features/entry/external-file-drop-controller.ts
@@ -1,0 +1,270 @@
+import { Notice, normalizePath } from 'obsidian';
+import type { TFile } from 'obsidian';
+import type DragNDropPlugin from '../../plugin/main';
+import { FILE_DROP_TARGET_CLASS } from '../../shared/dom-selectors';
+import { DND_BLOCK_TRANSFER_MIME_TYPE } from '../../shared/drag';
+import {
+    getActiveDragSourceBlock,
+    getActiveDragSourceView,
+} from '../state/drag-session';
+import {
+    finishDragSession,
+    getDragSourceBlockFromEvent,
+} from '../ui/indicator/ghost-element';
+import { FileBlockMover } from '../mutation/file-block-mover';
+
+type FileDropTarget = {
+    file: TFile;
+    element: HTMLElement;
+};
+
+type MarkdownViewWithFile = {
+    file?: TFile | null;
+    containerEl?: HTMLElement;
+    getViewType?: () => string;
+};
+
+const SIDEBAR_FILE_SELECTOR = '.nav-file-title[data-path]';
+const INTERNAL_LINK_SELECTOR = 'a.internal-link, .internal-link[data-href], .cm-hmd-internal-link[data-href]';
+
+export class ExternalFileDropController {
+    private readonly fileBlockMover: FileBlockMover;
+    private highlightedTarget: HTMLElement | null = null;
+
+    constructor(private readonly plugin: DragNDropPlugin) {
+        this.fileBlockMover = new FileBlockMover(plugin.app);
+    }
+
+    register(): void {
+        this.plugin.registerDomEvent(document, 'dragover', this.onDragOver, true);
+        this.plugin.registerDomEvent(document, 'dragleave', this.onDragLeave, true);
+        this.plugin.registerDomEvent(document, 'drop', this.onDrop, true);
+        this.plugin.registerDomEvent(document, 'dragend', this.onDragEnd, true);
+    }
+
+    private readonly onDragOver = (event: DragEvent): void => {
+        const target = this.resolveDropTarget(event);
+        if (!target) {
+            this.clearHighlight();
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = 'move';
+        }
+        this.setHighlightedTarget(target.element);
+    };
+
+    private readonly onDragLeave = (event: DragEvent): void => {
+        if (!this.highlightedTarget) return;
+        const nextTarget = event.relatedTarget instanceof Node ? event.relatedTarget : null;
+        if (nextTarget && this.highlightedTarget.contains(nextTarget)) return;
+        this.clearHighlight();
+    };
+
+    private readonly onDrop = (event: DragEvent): void => {
+        const target = this.resolveDropTarget(event);
+        if (!target) {
+            this.clearHighlight();
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        this.clearHighlight();
+
+        const sourceView = getActiveDragSourceView();
+        const sourceBlock = this.getSourceBlock(event);
+        if (!sourceView || !sourceBlock) {
+            finishDragSession();
+            new Notice('Dragger could not find the dragged block.');
+            return;
+        }
+
+        void this.fileBlockMover.moveBlockToFile({
+            sourceView,
+            sourceBlock,
+            targetFile: target.file,
+        }).then((result) => {
+            if (!result.moved) {
+                new Notice('Dragger could not move this block to the target note.');
+            }
+        }).catch((error) => {
+            console.error('[Dragger] failed to move block to file target:', error);
+            new Notice('Dragger could not move this block to the target note.');
+        }).finally(() => {
+            finishDragSession();
+        });
+    };
+
+    private readonly onDragEnd = (): void => {
+        this.clearHighlight();
+    };
+
+    private resolveDropTarget(event: DragEvent): FileDropTarget | null {
+        if (!this.isFileDropEnabled()) return null;
+        if (!hasBlockTransfer(event)) return null;
+        const sourceView = getActiveDragSourceView();
+        if (!sourceView || !getActiveDragSourceBlock(sourceView)) return null;
+
+        const target = event.target instanceof HTMLElement ? event.target : null;
+        if (!target) return null;
+
+        const sidebarFile = target.closest<HTMLElement>(SIDEBAR_FILE_SELECTOR);
+        if (sidebarFile) {
+            const file = this.resolveSidebarFileTarget(sidebarFile);
+            if (file) return { file, element: sidebarFile };
+        }
+
+        const link = target.closest<HTMLElement>(INTERNAL_LINK_SELECTOR);
+        if (!link) return null;
+
+        const file = this.resolveInternalLinkTarget(link);
+        if (!file) return null;
+        return { file, element: link };
+    }
+
+    private resolveSidebarFileTarget(element: HTMLElement): TFile | null {
+        const rawPath = element.getAttribute('data-path');
+        if (!rawPath) return null;
+        return this.resolveMarkdownFileByVaultPath(rawPath);
+    }
+
+    private resolveInternalLinkTarget(element: HTMLElement): TFile | null {
+        const rawLinkpath = this.getInternalLinkPath(element);
+        if (!rawLinkpath) return null;
+
+        const contextPath = this.resolveLinkContextPath(element);
+        if (rawLinkpath.startsWith('#')) {
+            return contextPath ? this.resolveMarkdownFileByVaultPath(contextPath) : null;
+        }
+
+        const resolved = this.plugin.app.metadataCache.getFirstLinkpathDest(rawLinkpath, contextPath ?? '');
+        if (isMarkdownFile(resolved)) return resolved;
+        return this.resolveMarkdownFileByVaultPath(stripSubpath(rawLinkpath));
+    }
+
+    private getInternalLinkPath(element: HTMLElement): string | null {
+        const rawDataHref = element.getAttribute('data-href');
+        if (rawDataHref) return normalizeInternalLinkAttribute(rawDataHref);
+
+        if (element instanceof HTMLAnchorElement) {
+            const rawHref = element.getAttribute('href');
+            if (rawHref) return normalizeInternalLinkAttribute(rawHref);
+        }
+
+        return null;
+    }
+
+    private resolveLinkContextPath(element: HTMLElement): string | null {
+        for (const leaf of this.plugin.app.workspace.getLeavesOfType('markdown')) {
+            const view = leaf.view as MarkdownViewWithFile;
+            if (view.getViewType?.() !== 'markdown') continue;
+            if (!view.containerEl?.contains(element)) continue;
+            return view.file?.path ?? null;
+        }
+
+        const sourceView = getActiveDragSourceView();
+        if (!sourceView) return null;
+        for (const leaf of this.plugin.app.workspace.getLeavesOfType('markdown')) {
+            const view = leaf.view as MarkdownViewWithFile & {
+                editor?: { cm?: unknown };
+            };
+            if (view.editor?.cm === sourceView) {
+                return view.file?.path ?? null;
+            }
+        }
+        return null;
+    }
+
+    private resolveMarkdownFileByVaultPath(path: string): TFile | null {
+        const cleaned = stripSubpath(path);
+        if (!cleaned) return null;
+        const candidates = cleaned.endsWith('.md')
+            ? [cleaned]
+            : [cleaned, `${cleaned}.md`];
+
+        for (const candidate of candidates) {
+            const normalized = normalizePath(candidate);
+            const file = this.plugin.app.vault.getFileByPath(normalized)
+                ?? this.plugin.app.vault.getAbstractFileByPath(normalized);
+            if (isMarkdownFile(file)) return file;
+        }
+
+        return null;
+    }
+
+    private isFileDropEnabled(): boolean {
+        return this.plugin.settings.enableCrossFileDrag === true;
+    }
+
+    private getSourceBlock(event: DragEvent) {
+        try {
+            return getDragSourceBlockFromEvent(event);
+        } catch {
+            const sourceView = getActiveDragSourceView();
+            return sourceView ? getActiveDragSourceBlock(sourceView) : null;
+        }
+    }
+
+    private setHighlightedTarget(element: HTMLElement): void {
+        if (this.highlightedTarget === element) return;
+        this.clearHighlight();
+        this.highlightedTarget = element;
+        element.classList.add(FILE_DROP_TARGET_CLASS);
+    }
+
+    private clearHighlight(): void {
+        this.highlightedTarget?.classList.remove(FILE_DROP_TARGET_CLASS);
+        this.highlightedTarget = null;
+    }
+}
+
+function hasBlockTransfer(event: DragEvent): boolean {
+    const types = event.dataTransfer?.types;
+    if (!types) return false;
+    return Array.from(types).includes(DND_BLOCK_TRANSFER_MIME_TYPE);
+}
+
+function normalizeInternalLinkAttribute(value: string): string | null {
+    let linkpath = safelyDecodeURIComponent(value.trim());
+    if (!linkpath.length) return null;
+    if (/^(https?|mailto):/i.test(linkpath)) return null;
+
+    if (linkpath.startsWith('#')) {
+        return linkpath;
+    }
+
+    if (linkpath.startsWith('/')) {
+        linkpath = linkpath.slice(1);
+    }
+
+    const aliasIndex = linkpath.indexOf('|');
+    if (aliasIndex >= 0) {
+        linkpath = linkpath.slice(0, aliasIndex);
+    }
+
+    return linkpath.trim() || null;
+}
+
+function stripSubpath(path: string): string {
+    const hashIndex = path.indexOf('#');
+    return (hashIndex >= 0 ? path.slice(0, hashIndex) : path).trim();
+}
+
+function safelyDecodeURIComponent(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}
+
+function isMarkdownFile(file: unknown): file is TFile {
+    const candidate = file as TFile | null;
+    return !!candidate
+        && typeof candidate.path === 'string'
+        && candidate.extension === 'md';
+}

--- a/src/features/mutation/file-block-mover.spec.ts
+++ b/src/features/mutation/file-block-mover.spec.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+import { EditorState } from '@codemirror/state';
+import type { TransactionSpec } from '@codemirror/state';
+import type { EditorView } from '@codemirror/view';
+import type { App, TFile } from 'obsidian';
+import { describe, expect, it, vi } from 'vitest';
+import { BlockInfo, BlockType } from '../../core/block/block-types';
+import { appendMarkdownBlock, FileBlockMover } from './file-block-mover';
+
+describe('FileBlockMover', () => {
+    it('appends a block to a closed target file and deletes it from the source editor', async () => {
+        const sourceView = createMutableView('before\nmove me\nafter');
+        let targetContent = 'Archive';
+        const targetFile = createMarkdownFile('Archive.md');
+        const app = createAppStub({
+            processFile: async (_file, fn) => {
+                targetContent = fn(targetContent);
+                return targetContent;
+            },
+        });
+
+        const result = await new FileBlockMover(app).moveBlockToFile({
+            sourceView,
+            sourceBlock: createBlock(1, 1),
+            targetFile,
+        });
+
+        expect(result.moved).toBe(true);
+        expect(sourceView.state.doc.toString()).toBe('before\nafter');
+        expect(targetContent).toBe('Archive\n\nmove me');
+    });
+
+    it('moves composite selections into a target file as one appended block', async () => {
+        const sourceView = createMutableView('one\ntwo\nthree\nfour');
+        let targetContent = '';
+        const app = createAppStub({
+            processFile: async (_file, fn) => {
+                targetContent = fn(targetContent);
+                return targetContent;
+            },
+        });
+
+        const result = await new FileBlockMover(app).moveBlockToFile({
+            sourceView,
+            sourceBlock: {
+                ...createBlock(0, 2),
+                compositeSelection: {
+                    ranges: [
+                        { startLine: 0, endLine: 0 },
+                        { startLine: 2, endLine: 2 },
+                    ],
+                },
+            },
+            targetFile: createMarkdownFile('Archive.md'),
+        });
+
+        expect(result.moved).toBe(true);
+        expect(sourceView.state.doc.toString()).toBe('two\nfour');
+        expect(targetContent).toBe('one\nthree');
+    });
+
+    it('uses the open target editor when the target file is already open', async () => {
+        const sourceView = createMutableView('source\nmove');
+        const targetView = createMutableView('target');
+        const targetFile = createMarkdownFile('Archive.md');
+        const processFile = vi.fn();
+        const app = createAppStub({
+            leaves: [createMarkdownLeaf(targetFile, targetView)],
+            processFile,
+        });
+
+        const result = await new FileBlockMover(app).moveBlockToFile({
+            sourceView,
+            sourceBlock: createBlock(1, 1),
+            targetFile,
+        });
+
+        expect(result.moved).toBe(true);
+        expect(processFile).not.toHaveBeenCalled();
+        expect(sourceView.state.doc.toString()).toBe('source');
+        expect(targetView.state.doc.toString()).toBe('target\n\nmove');
+    });
+
+    it('can move a block to the end of its own file', async () => {
+        const targetFile = createMarkdownFile('Daily.md');
+        const sourceView = createMutableView('keep\nmove');
+        const app = createAppStub({
+            leaves: [createMarkdownLeaf(targetFile, sourceView)],
+        });
+
+        const result = await new FileBlockMover(app).moveBlockToFile({
+            sourceView,
+            sourceBlock: createBlock(1, 1),
+            targetFile,
+        });
+
+        expect(result.moved).toBe(true);
+        expect(sourceView.state.doc.toString()).toBe('keep\n\nmove');
+    });
+});
+
+describe('appendMarkdownBlock', () => {
+    it('keeps readable spacing when appending to existing notes', () => {
+        expect(appendMarkdownBlock('', 'moved\n')).toBe('moved');
+        expect(appendMarkdownBlock('archive', 'moved')).toBe('archive\n\nmoved');
+        expect(appendMarkdownBlock('archive\n', 'moved')).toBe('archive\n\nmoved');
+        expect(appendMarkdownBlock('archive\n\n', 'moved')).toBe('archive\n\nmoved');
+    });
+});
+
+function createMutableView(initialDoc: string): EditorView {
+    let state = EditorState.create({ doc: initialDoc });
+    return {
+        get state() {
+            return state;
+        },
+        dispatch(spec: TransactionSpec) {
+            state = state.update(spec).state;
+        },
+    } as unknown as EditorView;
+}
+
+function createBlock(startLine: number, endLine: number): BlockInfo {
+    return {
+        type: BlockType.Paragraph,
+        startLine,
+        endLine,
+        from: 0,
+        to: 0,
+        indentLevel: 0,
+        content: '',
+    };
+}
+
+function createMarkdownFile(path: string): TFile {
+    const extension = path.split('.').pop() ?? '';
+    return {
+        path,
+        name: path.split('/').pop() ?? path,
+        basename: path.replace(/\.md$/, ''),
+        extension,
+    } as TFile;
+}
+
+function createMarkdownLeaf(file: TFile, editorView: EditorView) {
+    return {
+        view: {
+            file,
+            editor: { cm: editorView },
+            getViewType: () => 'markdown',
+        },
+    };
+}
+
+function createAppStub(options?: {
+    leaves?: ReturnType<typeof createMarkdownLeaf>[];
+    processFile?: (file: TFile, fn: (data: string) => string) => Promise<string>;
+}): App {
+    const processFile = options?.processFile ?? (async (_file: TFile, fn: (data: string) => string) => fn(''));
+    return {
+        workspace: {
+            getLeavesOfType: () => options?.leaves ?? [],
+        },
+        vault: {
+            process: processFile,
+        },
+    } as unknown as App;
+}

--- a/src/features/mutation/file-block-mover.spec.ts
+++ b/src/features/mutation/file-block-mover.spec.ts
@@ -8,6 +8,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { BlockInfo, BlockType } from '../../core/block/block-types';
 import { appendMarkdownBlock, FileBlockMover } from './file-block-mover';
 
+type MutableView = EditorView & {
+    dispatchCount: number;
+};
+
 describe('FileBlockMover', () => {
     it('appends a block to a closed target file and deletes it from the source editor', async () => {
         const sourceView = createMutableView('before\nmove me\nafter');
@@ -97,6 +101,25 @@ describe('FileBlockMover', () => {
 
         expect(result.moved).toBe(true);
         expect(sourceView.state.doc.toString()).toBe('keep\n\nmove');
+        expect(sourceView.dispatchCount).toBe(1);
+    });
+
+    it('keeps a whole-file same-file move to one undoable dispatch without extra padding', async () => {
+        const targetFile = createMarkdownFile('Daily.md');
+        const sourceView = createMutableView('move');
+        const app = createAppStub({
+            leaves: [createMarkdownLeaf(targetFile, sourceView)],
+        });
+
+        const result = await new FileBlockMover(app).moveBlockToFile({
+            sourceView,
+            sourceBlock: createBlock(0, 0),
+            targetFile,
+        });
+
+        expect(result.moved).toBe(true);
+        expect(sourceView.state.doc.toString()).toBe('move');
+        expect(sourceView.dispatchCount).toBe(1);
     });
 });
 
@@ -109,16 +132,21 @@ describe('appendMarkdownBlock', () => {
     });
 });
 
-function createMutableView(initialDoc: string): EditorView {
+function createMutableView(initialDoc: string): MutableView {
     let state = EditorState.create({ doc: initialDoc });
+    let dispatchCount = 0;
     return {
         get state() {
             return state;
         },
+        get dispatchCount() {
+            return dispatchCount;
+        },
         dispatch(spec: TransactionSpec) {
+            dispatchCount += 1;
             state = state.update(spec).state;
         },
-    } as unknown as EditorView;
+    } as unknown as MutableView;
 }
 
 function createBlock(startLine: number, endLine: number): BlockInfo {

--- a/src/features/mutation/file-block-mover.ts
+++ b/src/features/mutation/file-block-mover.ts
@@ -1,0 +1,186 @@
+import type { EditorView } from '@codemirror/view';
+import type { App, MarkdownView, TFile } from 'obsidian';
+import { BlockInfo } from '../../core/block/block-types';
+import { LineParsingService } from '../../core/parser/line-parsing-service';
+import { DocLikeWithRange } from '../../shared/types/protocol-types';
+import { normalizeCompositeRanges } from '../../shared/utils/composite-selection';
+import { getCodeMirrorView } from '../../platform/obsidian/editor-view';
+import { ListRenumberer } from './list-renumberer';
+
+type SourceSegment = {
+    startLineNumber: number;
+    from: number;
+    to: number;
+    deleteFrom: number;
+    deleteTo: number;
+};
+
+type SourcePayload = {
+    content: string;
+    segments: SourceSegment[];
+};
+
+type MarkdownViewWithFile = MarkdownView & {
+    file?: TFile | null;
+};
+
+export type FileBlockMoveResult = {
+    moved: boolean;
+    reason?: string;
+};
+
+export class FileBlockMover {
+    constructor(private readonly app: App) { }
+
+    async moveBlockToFile(params: {
+        sourceView: EditorView;
+        sourceBlock: BlockInfo;
+        targetFile: TFile;
+    }): Promise<FileBlockMoveResult> {
+        const { sourceView, sourceBlock, targetFile } = params;
+        if (targetFile.extension !== 'md') {
+            return { moved: false, reason: 'target_not_markdown' };
+        }
+
+        const payload = this.captureSourcePayload(sourceView, sourceBlock);
+        if (!payload || payload.content.length === 0) {
+            return { moved: false, reason: 'empty_source' };
+        }
+
+        const targetView = this.getOpenMarkdownEditorView(targetFile);
+        if (targetView === sourceView) {
+            this.deleteSourcePayload(sourceView, payload);
+            this.appendToEditor(targetView, payload.content);
+            this.renumberSourceLists(sourceView, payload);
+            return { moved: true };
+        }
+
+        if (targetView) {
+            this.appendToEditor(targetView, payload.content);
+            this.deleteSourcePayload(sourceView, payload);
+            this.renumberSourceLists(sourceView, payload);
+            return { moved: true };
+        }
+
+        await this.app.vault.process(targetFile, (data) => appendMarkdownBlock(data, payload.content));
+        this.deleteSourcePayload(sourceView, payload);
+        this.renumberSourceLists(sourceView, payload);
+        return { moved: true };
+    }
+
+    private getOpenMarkdownEditorView(file: TFile): EditorView | null {
+        for (const leaf of this.app.workspace.getLeavesOfType('markdown')) {
+            const view = leaf.view;
+            if (view.getViewType?.() !== 'markdown') continue;
+            const markdownView = view as MarkdownViewWithFile;
+            if (markdownView.file?.path !== file.path) continue;
+            return getCodeMirrorView(markdownView);
+        }
+        return null;
+    }
+
+    private captureSourcePayload(sourceView: EditorView, sourceBlock: BlockInfo): SourcePayload | null {
+        const doc = sourceView.state.doc as unknown as DocLikeWithRange;
+        const rawRanges = sourceBlock.compositeSelection?.ranges ?? [{
+            startLine: sourceBlock.startLine,
+            endLine: sourceBlock.endLine,
+        }];
+        const ranges = normalizeCompositeRanges(rawRanges, doc.lines);
+        if (ranges.length === 0) return null;
+
+        const segments = ranges.map((range) => {
+            const startLineNumber = range.startLine + 1;
+            const endLineNumber = range.endLine + 1;
+            const startLine = doc.line(startLineNumber);
+            const endLine = doc.line(endLineNumber);
+            const deleteRange = resolveDeleteRange(doc, startLine.from, endLine.to);
+            return {
+                startLineNumber,
+                from: startLine.from,
+                to: endLine.to,
+                deleteFrom: deleteRange.from,
+                deleteTo: deleteRange.to,
+            };
+        });
+        const content = segments
+            .map((segment) => doc.sliceString(segment.from, segment.to))
+            .join('\n');
+
+        return { content, segments };
+    }
+
+    private appendToEditor(view: EditorView, content: string): void {
+        const doc = view.state.doc as unknown as DocLikeWithRange;
+        const insert = buildAppendInsertion(doc.sliceString(0, doc.length), content);
+        if (!insert.length) return;
+        view.dispatch({
+            changes: { from: doc.length, to: doc.length, insert },
+            scrollIntoView: false,
+        });
+    }
+
+    private deleteSourcePayload(sourceView: EditorView, payload: SourcePayload): void {
+        const changes = payload.segments
+            .map((segment) => ({
+                from: segment.deleteFrom,
+                to: segment.deleteTo,
+            }))
+            .sort((a, b) => b.from - a.from);
+        if (changes.length === 0) return;
+        sourceView.dispatch({
+            changes,
+            scrollIntoView: false,
+        });
+    }
+
+    private renumberSourceLists(sourceView: EditorView, payload: SourcePayload): void {
+        const lineParsing = new LineParsingService(sourceView);
+        const renumberer = new ListRenumberer({
+            view: sourceView,
+            parseLineWithQuote: (line) => lineParsing.parseLine(line),
+        });
+        const lineNumbers = new Set(payload.segments.map((segment) => segment.startLineNumber));
+        for (const lineNumber of lineNumbers) {
+            renumberer.renumberOrderedListAround(lineNumber);
+        }
+    }
+}
+
+export function appendMarkdownBlock(existing: string, blockContent: string): string {
+    const insert = buildAppendInsertion(existing, blockContent);
+    return insert.length ? `${existing}${insert}` : existing;
+}
+
+function buildAppendInsertion(existing: string, blockContent: string): string {
+    const normalized = blockContent.replace(/\n+$/, '');
+    if (!normalized.length) return '';
+    if (!existing.length) return normalized;
+    if (existing.endsWith('\n\n')) return normalized;
+    if (existing.endsWith('\n')) return `\n${normalized}`;
+    return `\n\n${normalized}`;
+}
+
+function resolveDeleteRange(
+    doc: DocLikeWithRange,
+    sourceFrom: number,
+    sourceTo: number
+): { from: number; to: number } {
+    if (sourceTo < doc.length) {
+        return {
+            from: sourceFrom,
+            to: Math.min(sourceTo + 1, doc.length),
+        };
+    }
+
+    if (sourceFrom > 0) {
+        return {
+            from: sourceFrom - 1,
+            to: sourceTo,
+        };
+    }
+
+    return {
+        from: sourceFrom,
+        to: sourceTo,
+    };
+}

--- a/src/features/mutation/file-block-mover.ts
+++ b/src/features/mutation/file-block-mover.ts
@@ -20,6 +20,12 @@ type SourcePayload = {
     segments: SourceSegment[];
 };
 
+type TextChange = {
+    from: number;
+    to: number;
+    insert?: string;
+};
+
 type MarkdownViewWithFile = MarkdownView & {
     file?: TFile | null;
 };
@@ -49,8 +55,7 @@ export class FileBlockMover {
 
         const targetView = this.getOpenMarkdownEditorView(targetFile);
         if (targetView === sourceView) {
-            this.deleteSourcePayload(sourceView, payload);
-            this.appendToEditor(targetView, payload.content);
+            this.moveWithinSameEditorToEnd(sourceView, payload);
             this.renumberSourceLists(sourceView, payload);
             return { moved: true };
         }
@@ -120,17 +125,52 @@ export class FileBlockMover {
     }
 
     private deleteSourcePayload(sourceView: EditorView, payload: SourcePayload): void {
-        const changes = payload.segments
-            .map((segment) => ({
-                from: segment.deleteFrom,
-                to: segment.deleteTo,
-            }))
-            .sort((a, b) => b.from - a.from);
+        const changes = this.getMergedDeleteChanges(payload).sort((a, b) => b.from - a.from);
         if (changes.length === 0) return;
         sourceView.dispatch({
             changes,
             scrollIntoView: false,
         });
+    }
+
+    private moveWithinSameEditorToEnd(view: EditorView, payload: SourcePayload): void {
+        const doc = view.state.doc as unknown as DocLikeWithRange;
+        const deletes = this.getMergedDeleteChanges(payload);
+        const remainingText = applyDeleteChanges(doc.sliceString(0, doc.length), deletes);
+        const insert = buildAppendInsertion(remainingText, payload.content);
+        const changes: TextChange[] = [
+            ...deletes,
+            ...(insert.length ? [{ from: doc.length, to: doc.length, insert }] : []),
+        ].sort((a, b) => b.from - a.from);
+        if (changes.length === 0) return;
+        view.dispatch({
+            changes,
+            scrollIntoView: false,
+        });
+    }
+
+    private getMergedDeleteChanges(payload: SourcePayload): TextChange[] {
+        const sorted = payload.segments
+            .map((segment) => ({
+                from: segment.deleteFrom,
+                to: segment.deleteTo,
+            }))
+            .sort((a, b) => a.from - b.from);
+
+        const merged: TextChange[] = [];
+        for (const change of sorted) {
+            const last = merged[merged.length - 1];
+            if (!last) {
+                merged.push(change);
+                continue;
+            }
+            if (change.from <= last.to) {
+                last.to = Math.max(last.to, change.to);
+                continue;
+            }
+            merged.push(change);
+        }
+        return merged;
     }
 
     private renumberSourceLists(sourceView: EditorView, payload: SourcePayload): void {
@@ -158,6 +198,16 @@ function buildAppendInsertion(existing: string, blockContent: string): string {
     if (existing.endsWith('\n\n')) return normalized;
     if (existing.endsWith('\n')) return `\n${normalized}`;
     return `\n\n${normalized}`;
+}
+
+function applyDeleteChanges(existing: string, deletes: TextChange[]): string {
+    let result = '';
+    let cursor = 0;
+    for (const change of deletes) {
+        result += existing.slice(cursor, change.from);
+        cursor = change.to;
+    }
+    return result + existing.slice(cursor);
 }
 
 function resolveDeleteRange(

--- a/src/plugin/i18n/en.ts
+++ b/src/plugin/i18n/en.ts
@@ -53,6 +53,6 @@ export const en: ZhCnStrings = {
     mobileTextLongPressDrag: 'Mobile text long-press drag',
     mobileTextLongPressDragDesc: 'On mobile, long-press a text line or rendered block content to drag the current block directly without using the left handle',
     enableCrossFileDrag: 'Cross-file drag',
-    enableCrossFileDragDesc: 'Allow dragging blocks into another open file editor',
+    enableCrossFileDragDesc: 'Allow dragging blocks into open editors, internal links, and file explorer notes',
 
 };

--- a/src/plugin/i18n/zh-cn.ts
+++ b/src/plugin/i18n/zh-cn.ts
@@ -59,7 +59,7 @@ export const zhCn = {
     mobileTextLongPressDrag: '移动端文本长按拖拽',
     mobileTextLongPressDragDesc: '移动端在文本整行或块内容区域长按可直接拖拽当前块，无需左侧手柄',
     enableCrossFileDrag: '跨文件拖拽',
-    enableCrossFileDragDesc: '允许将块拖拽到另一个已打开文件的编辑器中',
+    enableCrossFileDragDesc: '允许将块拖拽到已打开编辑器、内部链接或文件列表笔记中',
 
 };
 

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -1,5 +1,6 @@
 import { Plugin } from 'obsidian';
 import { dragHandleExtension } from '../features/entry/extension-factory';
+import { ExternalFileDropController } from '../features/entry/external-file-drop-controller';
 import { setHandleHorizontalOffsetPx, setHandleSizePx } from '../shared/constants';
 import {
     DND_DRAG_SOURCE_HIGHLIGHT_ATTR,
@@ -28,6 +29,8 @@ export default class DragNDropPlugin extends Plugin {
 
         // 注册编辑器扩展
         this.registerEditorExtension(dragHandleExtension(this));
+        const externalFileDropController = new ExternalFileDropController(this);
+        externalFileDropController.register();
 
         // 添加设置面板
         this.addSettingTab(new DragNDropSettingTab(this.app, this));
@@ -161,5 +164,3 @@ export default class DragNDropPlugin extends Plugin {
         }
     }
 }
-
-

--- a/src/shared/dom-selectors.ts
+++ b/src/shared/dom-selectors.ts
@@ -47,4 +47,5 @@ export const RANGE_SELECTED_LINE_CLASS = 'dnd-range-selected-line';
 export const RANGE_SELECTED_HANDLE_CLASS = 'dnd-range-selected-handle';
 export const RANGE_SELECTION_LINK_CLASS = 'dnd-range-selection-link';
 export const RANGE_SELECTION_DELETE_BUTTON_CLASS = 'dnd-range-selection-delete-btn';
+export const FILE_DROP_TARGET_CLASS = 'dnd-file-drop-target';
 export const MOBILE_GESTURE_LOCK_CLASS = 'dnd-mobile-gesture-lock';

--- a/styles.css
+++ b/styles.css
@@ -428,6 +428,13 @@ body.dnd-mobile-gesture-lock {
     z-index: 1000;
 }
 
+.dnd-file-drop-target {
+    outline: 2px solid var(--dnd-drop-indicator-color, var(--interactive-accent));
+    outline-offset: 2px;
+    background: var(--dnd-drop-highlight-bg, color-mix(in srgb, var(--interactive-accent) 10%, transparent));
+    border-radius: 4px;
+}
+
 /* 放置位置指示器 */
 .dnd-drop-indicator {
     position: fixed;
@@ -452,4 +459,3 @@ body.dnd-mobile-gesture-lock {
 body[data-dnd-list-drop-highlight="off"] .dnd-drop-highlight {
     display: none !important;
 }
-


### PR DESCRIPTION
Implements the feature requested in #35: dragging a section/block onto an internal linked note or a note in the file explorer now moves that block into the target note.

This keeps the existing editor-to-editor drag behavior and extends the existing Cross-file drag setting to cover linked pages and file explorer notes.

Review feedback addressed:
- Removed user-specific npm scripts from package.json; local vault builds can use OBSIDIAN_PLUGIN_DIR with the existing build script.
- Strip heading/subpath fragments before resolving internal link targets.
- Use optional vault.getFileByPath for older Obsidian compatibility.
- Make same-file note drops one atomic dispatch and merge delete ranges for robust composite moves.

Validation:
- npm run lint
- npm run typecheck
- npm run test
- OBSIDIAN_PLUGIN_DIR=/private/tmp/obsidian-dragger-plugin npm run build