### PR TITLE
fix(i18n): detect locale with Obsidian getLanguage API

### DIFF
--- a/src/plugin/i18n/index.spec.ts
+++ b/src/plugin/i18n/index.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { en } from './en';
+import { detectLanguage, selectTranslations } from './index';
+import { ru } from './ru';
+import { zhCn } from './zh-cn';
+
+describe('i18n locale selection', () => {
+    it('prefers and normalizes Obsidian getLanguage()', () => {
+        const language = detectLanguage({
+            getLanguage: () => ' zh-CN ',
+            moment: {
+                locale: () => {
+                    throw new Error('legacy locale detection should not run');
+                },
+            },
+        });
+
+        expect(language).toBe('zh-cn');
+    });
+
+    it('falls back to moment.locale() when getLanguage is unavailable', () => {
+        const language = detectLanguage({
+            moment: {
+                locale: () => 'RU',
+            },
+        });
+
+        expect(language).toBe('ru');
+    });
+
+    it.each([
+        ['zh', zhCn],
+        ['zh-CN', zhCn],
+        ['zh-cn', zhCn],
+        ['zh-TW', zhCn],
+        ['zh-HK', zhCn],
+        ['en', en],
+        ['en-US', en],
+        ['ru-RU', ru],
+        ['fr', en],
+    ])('selects the expected dictionary for %s', (language, expected) => {
+        expect(selectTranslations(language)).toBe(expected);
+    });
+});

--- a/src/plugin/i18n/index.ts
+++ b/src/plugin/i18n/index.ts
@@ -1,11 +1,40 @@
-import { moment } from 'obsidian';
+import * as obsidian from 'obsidian';
 import { en } from './en';
 import { zhCn } from './zh-cn';
 import { ru } from './ru';
 
 export type I18nStrings = typeof zhCn;
 
+type LanguageApi = {
+    getLanguage?: () => string;
+    moment: {
+        locale(): string;
+    };
+};
+
+const translationsByLocale: Record<string, I18nStrings> = {
+    en,
+    ru,
+    zh: zhCn,
+    'zh-cn': zhCn,
+    'zh-hk': zhCn,
+    'zh-tw': zhCn,
+};
+
+export function detectLanguage(api: LanguageApi): string {
+    const language = typeof api.getLanguage === 'function'
+        ? api.getLanguage()
+        : api.moment.locale();
+    return language.trim().toLowerCase();
+}
+
+export function selectTranslations(language: string): I18nStrings {
+    const normalizedLanguage = language.trim().toLowerCase();
+    return translationsByLocale[normalizedLanguage]
+        ?? translationsByLocale[normalizedLanguage.split('-')[0]]
+        ?? en;
+}
+
 export function t(): I18nStrings {
-    const locale = moment.locale();
-    return locale.startsWith('zh') ? zhCn : locale.startsWith('ru') ? ru : en;
+    return selectTranslations(detectLanguage(obsidian));
 }


### PR DESCRIPTION
## Summary

- prefer Obsidian's official `getLanguage()` API
- preserve compatibility with Obsidian versions before 1.8.7 through a runtime feature check and the existing `moment.locale()` fallback
- normalize locale codes and check exact regional locales before base-language fallback
- add focused tests for language detection and dictionary selection

## Problem

The plugin used `moment.locale()` as its UI language source. Moment's date locale can differ from Obsidian's current interface language, causing settings that have Simplified Chinese translations to appear in English.

## Related issues

Partially addresses #50.

This PR fixes locale selection for settings that are already backed by the i18n dictionaries. It does not translate commands or block-operation menus that are still hard-coded in English, so #50 can remain open for broader localization work.

## Compatibility

The manifest still declares Obsidian 1.2.3 as the minimum supported version. The built plugin accesses the external `obsidian` module through a namespace object and checks `typeof api.getLanguage === "function"` before calling it, so older versions safely fall back to `moment.locale()`.

This repository currently has one Chinese dictionary (`zh-cn`) and no Traditional Chinese dictionary. `zh-TW` and `zh-HK` therefore continue to select the existing Chinese dictionary instead of falling back to English.

## Verification

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint:review`
- [x] `npm test` (47 files, 333 tests)
- [x] Simplified Chinese locale selection (`zh`, `zh-CN`, `zh-cn`)
- [x] Traditional Chinese region selection where supported (`zh-TW`, `zh-HK` select the repository's only Chinese dictionary)
- [x] English, Russian, and unsupported-locale fallback
- [x] inspected `dist/main.js`: `obsidian` remains external and the legacy branch cannot call a missing `getLanguage`

No dependency or lockfile changes are included.
