### PR TITLE
feat: drop dragged blocks onto linked and sidebar notes

### DIFF
--- a/docs/superpowers/specs/2026-08-16-external-target-and-native-selection-design.md
+++ b/docs/superpowers/specs/2026-08-16-external-target-and-native-selection-design.md
@@ -1,0 +1,143 @@
+# External Note Targets and Native Selection Drag
+
+**Status:** Approved design
+
+**Date:** 2026-08-16
+
+**Repositories:** `Ariestar/md-dragger`, `Ariestar/obsidian-dragger`
+
+## Goal
+
+Restore and modernize the intended cross-note workflow without reintroducing a parallel drag controller:
+
+1. Drag selected Markdown blocks onto an Obsidian internal link or File Explorer note and append them to that note.
+2. Use a native CodeMirror text selection spanning semantic blocks as the drag source when the user drags a handle inside that selection.
+3. Preserve current positional drops between open editors and the engine's long-press/handle multi-selection workflow.
+4. Keep selected handles recognizable as drag grips instead of rendering them as checkbox-like controls.
+
+The implementation must follow the 2.0 layering rule: generic selection, target, and commit extensibility belongs in `md-dragger`; Obsidian link, workspace, and vault knowledge remains in `obsidian-dragger`.
+
+## Non-goals
+
+- No changes to Obsidian itself.
+- No restoration of the pre-2.0 `ExternalFileDropController` or a second drag state machine.
+- No positional insertion into a note represented only by a link or sidebar item; those targets append to the end.
+- No new settings or dependencies.
+- No copy semantics: a successful external drop moves the source blocks.
+
+## Repository and PR structure
+
+### PR 1: `md-dragger`
+
+Add narrow, platform-neutral engine hooks:
+
+- A press-selection hook that can return a semantic `BlockSelection` for the pressed source. The default remains `selectOne(detectedBlock)`.
+- A target-location hook that may resolve a pointer to a `DropPosition` backed by a document not owned by a registered CodeMirror view.
+- A commit hook that receives planned `DocEdit[]` and may apply edits to non-CodeMirror documents. The existing CodeMirror commit behavior remains the default.
+
+The engine must not import or name Obsidian concepts such as `TFile`, vaults, internal links, or File Explorer nodes.
+
+### PR 2: `obsidian-dragger`
+
+Consume the new hooks to provide:
+
+- CodeMirror native-selection to semantic-block translation.
+- Internal-link and File Explorer target resolution through Obsidian APIs.
+- Append-at-end drop positions for unopened Markdown files.
+- Commit routing to open CodeMirror views or unopened vault files.
+- Grip-preserving selected-handle styling.
+
+The plugin PR depends on the engine PR and updates the pinned `md-dragger` version only after the engine release exists. Local development uses the documented sibling checkout link.
+
+## Interaction behavior
+
+### Native editor selection
+
+When a desktop CodeMirror selection is non-empty and spans more than one semantic block:
+
+1. Convert every selection range to complete Markdown blocks using engine domain helpers.
+2. Merge overlapping and adjacent block ranges.
+3. Use the resulting block selection only if the pressed handle belongs to it.
+4. Start the group drag using the normal movement threshold, without requiring the engine's additional multi-select hold delay.
+
+An empty selection, a selection resolving to one ordinary block, or a handle outside the selection follows existing single-block behavior. Engine-created persistent multi-selection remains unchanged.
+
+### Internal-link target
+
+During an active drag, the plugin recognizes Obsidian internal-link elements. It:
+
+1. Reads and safely decodes the link path.
+2. Removes aliases and heading/block subpaths before file resolution.
+3. Resolves the destination relative to the note containing the link through `metadataCache.getFirstLinkpathDest`.
+4. Accepts Markdown files only.
+5. Produces an append position at the end of the destination document.
+
+Same-note link drops use one CodeMirror transaction when the note is open. They must not duplicate or lose content.
+
+### File Explorer target
+
+During an active drag, the plugin recognizes `.nav-file-title[data-path]`, resolves its path to a Markdown `TFile`, and produces the same append-at-end target. Folders and non-Markdown files are ignored.
+
+### Commit ordering and failure safety
+
+For a destination not owned by an open CodeMirror view:
+
+1. Re-read the destination through `vault.process` at commit time.
+2. Recalculate the append edit against that current text.
+3. Persist the destination insertion first.
+4. Delete the source only after the destination write succeeds.
+
+If destination resolution or persistence fails, the engine cancels the drop and leaves the source untouched. Cross-file undo cannot be atomic across an unopened vault file; that limitation must be documented in the PR.
+
+Open-editor destinations continue through CodeMirror transactions and retain their editor undo behavior.
+
+## Visual feedback
+
+- Internal-link and File Explorer elements receive a temporary target-highlight class only while they are valid active targets.
+- The highlight is cleared on drop, cancel, pointer leave, view destruction, and plugin unload.
+- Selected blocks retain the current CodeMirror line decoration.
+- Selected handles retain the configured grip icon and gain an accent state; they do not transform into checkmarks or task-style checkboxes.
+
+## Engine API constraints
+
+- New hooks are optional and preserve current behavior when omitted.
+- Hooks return domain values rather than platform objects.
+- No duplicate controller, adapter wrapper, fallback path, or stale cached target is introduced.
+- The CodeMirror adapter remains the owner of default live-view hit testing and commits.
+- External targets are resolved fresh during drag-over and again on release.
+
+## Testing
+
+### `md-dragger`
+
+- Default press still selects one detected block when no hook exists.
+- A supplied press-selection hook starts a drag with its composite selection.
+- A supplied external locate hook can return a non-live document target.
+- A supplied commit hook receives the complete planned source and destination edits.
+- Rejected external targets produce no commit.
+- Existing CodeMirror adapter behavior remains green.
+
+### `obsidian-dragger`
+
+- Native text selection spanning paragraphs moves all resolved blocks.
+- Native selection works when the pressed handle is a nested list handle.
+- A handle outside the native selection moves only its own block.
+- Internal links resolve aliases, headings, block subpaths, relative paths, and encoded paths.
+- File Explorer Markdown files resolve; folders and non-Markdown files do not.
+- Link and sidebar drops append with correct newline formatting.
+- Failed destination writes leave the source unchanged.
+- Same-file append is one dispatch without overlapping changes.
+- Existing open-editor cross-file, single-block, long-press selection, list renumbering, and mobile behavior remain green.
+
+Both repositories must pass their full tests, type checks, lint checks, and production builds before either PR is proposed.
+
+## Acceptance criteria
+
+- Dropping selected blocks on an internal note link moves them to the end of the linked note.
+- Dropping selected blocks on a File Explorer note moves them to the end of that note.
+- Dragging a handle inside a native multi-block text selection moves the complete semantic selection.
+- Positional dragging into another open editor remains unchanged.
+- Long-press/handle multi-selection remains available.
+- Selected handles remain visibly draggable grips.
+- No Obsidian-specific type or behavior enters `md-dragger`.
+- No parallel drag controller is added to `obsidian-dragger`.

--- a/docs/superpowers/specs/2026-08-16-external-target-and-native-selection-design.md
+++ b/docs/superpowers/specs/2026-08-16-external-target-and-native-selection-design.md
@@ -32,8 +32,8 @@ The implementation must follow the 2.0 layering rule: generic selection, target,
 Add narrow, platform-neutral engine hooks:
 
 - A press-selection hook that can return a semantic `BlockSelection` for the pressed source. The default remains `selectOne(detectedBlock)`.
-- A target-location hook that may resolve a pointer to a `DropPosition` backed by a document not owned by a registered CodeMirror view.
-- A commit hook that receives planned `DocEdit[]` and may apply edits to non-CodeMirror documents. The existing CodeMirror commit behavior remains the default.
+- A tri-state external-target hook: `undefined` means "not an external target; continue normal CodeMirror hit-testing", `null` means "handled but invalid", and a `DropPosition` may reference a document not owned by a registered CodeMirror view.
+- An asynchronous commit hook that receives planned `DocEdit[]` and may apply edits to non-CodeMirror documents before the runtime publishes a successful drop. The existing synchronous CodeMirror commit behavior remains the default.
 
 The engine must not import or name Obsidian concepts such as `TFile`, vaults, internal links, or File Explorer nodes.
 
@@ -102,6 +102,9 @@ Open-editor destinations continue through CodeMirror transactions and retain the
 
 - New hooks are optional and preserve current behavior when omitted.
 - Hooks return domain values rather than platform objects.
+- The existing CodeMirror `resolveDropPosition` override remains unchanged; the new external-target hook runs before it and uses `undefined` as its only fall-through value.
+- Commit failure produces a rejected terminal result and never publishes a successful `dropped` output.
+- Once an asynchronous host commit starts on release, the runtime blocks new gesture/cancel transitions until it settles so platform side effects and the published terminal result cannot diverge.
 - No duplicate controller, adapter wrapper, fallback path, or stale cached target is introduced.
 - The CodeMirror adapter remains the owner of default live-view hit testing and commits.
 - External targets are resolved fresh during drag-over and again on release.
@@ -112,8 +115,9 @@ Open-editor destinations continue through CodeMirror transactions and retain the
 
 - Default press still selects one detected block when no hook exists.
 - A supplied press-selection hook starts a drag with its composite selection.
-- A supplied external locate hook can return a non-live document target.
-- A supplied commit hook receives the complete planned source and destination edits.
+- A supplied external target hook distinguishes fall-through, handled-invalid, and non-live document targets.
+- A supplied asynchronous commit hook receives the complete planned source and destination edits, and successful drop output waits for it.
+- A rejected asynchronous commit emits no successful drop and returns a rejected commit result.
 - Rejected external targets produce no commit.
 - Existing CodeMirror adapter behavior remains green.
 

--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -6,3 +6,13 @@ export const Platform = {
     isDesktop: true,
     isDesktopApp: true,
 };
+
+export class TFile {
+    path = '';
+    name = '';
+    basename = '';
+    extension = '';
+    parent = null;
+    vault = null;
+    stat = { ctime: 0, mtime: 0, size: 0 };
+}

--- a/src/architecture-boundary.spec.ts
+++ b/src/architecture-boundary.spec.ts
@@ -68,6 +68,7 @@ describe('plugin architecture boundaries', () => {
     it('hosts mdDragger from a single codemirror entry module', () => {
         const files = readProductionFiles()
             .filter((file) => file.rel.startsWith('src/platform/codemirror/'))
+            .filter((file) => /\bmdDragger\b/.test(file.text))
             .map((file) => file.rel)
             .sort();
         expect(files).toEqual(['src/platform/codemirror/obsidian-dragger.ts']);

--- a/src/platform/codemirror/drag-paint.spec.ts
+++ b/src/platform/codemirror/drag-paint.spec.ts
@@ -2,10 +2,16 @@
 import { EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { describe, expect, it } from 'vitest';
+import type { App } from 'obsidian';
 import { dragHandleExtension, type ObsidianDraggerHost } from './obsidian-dragger';
 
 function mockPlugin(): ObsidianDraggerHost {
     return {
+        app: {
+            workspace: { getLeavesOfType: () => [] },
+            metadataCache: { getFirstLinkpathDest: () => null },
+            vault: { getAbstractFileByPath: () => null },
+        } as unknown as App,
         settings: {
             enableMultiLineSelection: true,
             mouseRangeSelectLongPressMs: 700,

--- a/src/platform/codemirror/native-block-selection.spec.ts
+++ b/src/platform/codemirror/native-block-selection.spec.ts
@@ -1,0 +1,45 @@
+import { EditorState } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+import { detectBlock, hasBlock } from 'md-dragger/domain';
+import { nativeBlockSelection } from './native-block-selection';
+
+function stateWithSelection(doc: string, anchor: number, head: number): EditorState {
+    return EditorState.create({ doc, selection: { anchor, head } });
+}
+
+function blockAt(state: EditorState, line: number) {
+    const block = detectBlock(state.doc, line, { tabSize: 4 });
+    if (!block) throw new Error(`No block at line ${line}`);
+    return block;
+}
+
+describe('nativeBlockSelection', () => {
+    it('returns every semantic block in a native multi-block selection', () => {
+        const state = stateWithSelection('alpha\n\nbeta', 0, 11);
+
+        expect(nativeBlockSelection(state, blockAt(state, 1), 4)?.blocks).toHaveLength(2);
+    });
+
+    it('accepts a nested list handle contained by the native selection', () => {
+        const state = stateWithSelection('- parent\n  - child\n\nafter', 0, 20);
+        const child = blockAt(state, 2);
+        const selection = nativeBlockSelection(state, child, 4);
+
+        expect(selection).not.toBeNull();
+        expect(hasBlock(selection!, child)).toBe(true);
+    });
+
+    it('returns null when the pressed handle is outside the native selection', () => {
+        const state = stateWithSelection('alpha\n\nbeta\n\ngamma', 0, 11);
+
+        expect(nativeBlockSelection(state, blockAt(state, 5), 4)).toBeNull();
+    });
+
+    it('returns null for an empty or single-block native selection', () => {
+        const empty = stateWithSelection('alpha\n\nbeta', 1, 1);
+        const single = stateWithSelection('alpha\n\nbeta', 0, 5);
+
+        expect(nativeBlockSelection(empty, blockAt(empty, 1), 4)).toBeNull();
+        expect(nativeBlockSelection(single, blockAt(single, 1), 4)).toBeNull();
+    });
+});

--- a/src/platform/codemirror/native-block-selection.ts
+++ b/src/platform/codemirror/native-block-selection.ts
@@ -1,0 +1,17 @@
+import type { EditorState } from '@codemirror/state';
+import { type Block, type BlockSelection, hasBlock, selectBlocksInLineRanges } from 'md-dragger/domain';
+
+/** Translate non-empty native editor ranges to semantic drag blocks. */
+export function nativeBlockSelection(state: EditorState, anchorBlock: Block, tabSize: number): BlockSelection | null {
+    const ranges = state.selection.ranges
+        .filter((range) => !range.empty)
+        .map((range) => ({
+            startLine: state.doc.lineAt(range.from).number,
+            endLine: state.doc.lineAt(Math.max(range.from, range.to - 1)).number,
+        }));
+    if (ranges.length === 0) return null;
+
+    const selection = selectBlocksInLineRanges(state.doc, ranges, { tabSize });
+    if (selection.blocks.length < 2 || !hasBlock(selection, anchorBlock)) return null;
+    return selection;
+}

--- a/src/platform/codemirror/obsidian-dragger.ts
+++ b/src/platform/codemirror/obsidian-dragger.ts
@@ -27,6 +27,7 @@ import { openBlockTypeMenu } from '../../plugin/block-type-menu';
 import { DRAGGING_BODY_CLASS, MOBILE_GESTURE_LOCK_CLASS, ROOT_EDITOR_CLASS } from '../../shared/dom-selectors';
 import { createExternalNoteTargets, type ExternalNoteTargetService } from '../obsidian/external-note-targets';
 import { getCodeMirrorViewForFile, getMarkdownFileForCodeMirror } from '../obsidian/views';
+import { internalLinkpathAtOffset } from '../obsidian/note-drop-target';
 import { nativeBlockSelection } from './native-block-selection';
 
 /** Minimal plugin surface used by the editor extension. */
@@ -62,6 +63,12 @@ export function dragHandleExtension(plugin: ObsidianDraggerHost): Extension {
             sourceFile: () => getMarkdownFileForCodeMirror(plugin.app, view),
             viewForFile: (file) => getCodeMirrorViewForFile(plugin.app, file),
             elementAtPoint: (point) => view.dom.ownerDocument.elementFromPoint(point.x, point.y),
+            linkpathAtPoint: (point) => {
+                const position = view.posAtCoords(point);
+                if (position === null) return null;
+                const line = view.state.doc.lineAt(position);
+                return internalLinkpathAtOffset(line.text, position - line.from);
+            },
         });
         serviceByView.set(view, service);
         services.add(service);

--- a/src/platform/codemirror/obsidian-dragger.ts
+++ b/src/platform/codemirror/obsidian-dragger.ts
@@ -22,11 +22,16 @@ import {
 } from 'md-dragger/domain';
 import { dragSelectionDoc, dropSeamState, selectionFromOutputs, type PipelineResult } from 'md-dragger/runtime';
 import { autoScroll } from 'md-dragger/runtime/modules';
+import type { App } from 'obsidian';
 import { openBlockTypeMenu } from '../../plugin/block-type-menu';
 import { DRAGGING_BODY_CLASS, MOBILE_GESTURE_LOCK_CLASS, ROOT_EDITOR_CLASS } from '../../shared/dom-selectors';
+import { createExternalNoteTargets, type ExternalNoteTargetService } from '../obsidian/external-note-targets';
+import { getCodeMirrorViewForFile, getMarkdownFileForCodeMirror } from '../obsidian/views';
+import { nativeBlockSelection } from './native-block-selection';
 
 /** Minimal plugin surface used by the editor extension. */
 export type ObsidianDraggerHost = {
+    app: App;
     settings: {
         enableMultiLineSelection: boolean;
         mouseRangeSelectLongPressMs: number;
@@ -47,6 +52,21 @@ export type ObsidianDraggerHost = {
 const LIST_INDENT_UNIT = 4;
 
 export function dragHandleExtension(plugin: ObsidianDraggerHost): Extension {
+    const serviceByView = new WeakMap<EditorView, ExternalNoteTargetService>();
+    const services = new Set<ExternalNoteTargetService>();
+    const serviceFor = (view: EditorView): ExternalNoteTargetService => {
+        const existing = serviceByView.get(view);
+        if (existing) return existing;
+        const service = createExternalNoteTargets({
+            app: plugin.app,
+            sourceFile: () => getMarkdownFileForCodeMirror(plugin.app, view),
+            viewForFile: (file) => getCodeMirrorViewForFile(plugin.app, file),
+            elementAtPoint: (point) => view.dom.ownerDocument.elementFromPoint(point.x, point.y),
+        });
+        serviceByView.set(view, service);
+        services.add(service);
+        return service;
+    };
     const options: MdDraggerCodeMirrorOptions = {
         // tabSize is always read live from EditorState.tabSize by the adapter.
         config: {
@@ -81,8 +101,16 @@ export function dragHandleExtension(plugin: ObsidianDraggerHost): Extension {
                 return lineAtPoint(view, input.point);
             },
         }),
-        ux: {
+        externalTarget: (view) => ({
+            resolveDropPosition: (point, context) => serviceFor(view).resolve(point, context),
+        }),
+        commit: (view) => ({
+            apply: (edits) => serviceFor(view).apply(edits),
+        }),
+        ux: (view) => ({
             gesture: () => gestureConfig(plugin),
+            selectionFromInput: (_input, anchorBlock) =>
+                nativeBlockSelection(view.state, anchorBlock, view.state.facet(EditorState.tabSize)),
             modules: [
                 autoScroll(
                     // Adapter port scrolls the .cm-scroller under the pointer;
@@ -94,10 +122,13 @@ export function dragHandleExtension(plugin: ObsidianDraggerHost): Extension {
                     }),
                 ),
             ],
-        },
+        }),
         onChange: (result) => {
             for (const item of result.outputs) {
                 if (item.type === 'dropped') plugin.notifyDragDrop();
+                if (item.type === 'dropped' || item.type === 'cancelled' || item.type === 'terminal') {
+                    for (const service of services) service.clear();
+                }
             }
         },
     };
@@ -109,7 +140,28 @@ export function dragHandleExtension(plugin: ObsidianDraggerHost): Extension {
         selectionPaint(),
         handleHover(),
         gestureShell(plugin),
+        externalTargetCleanup(serviceFor, services),
     ];
+}
+
+function externalTargetCleanup(
+    serviceFor: (view: EditorView) => ExternalNoteTargetService,
+    services: Set<ExternalNoteTargetService>,
+): Extension {
+    return ViewPlugin.fromClass(
+        class {
+            private readonly service: ExternalNoteTargetService;
+
+            constructor(view: EditorView) {
+                this.service = serviceFor(view);
+            }
+
+            destroy() {
+                this.service.destroy();
+                services.delete(this.service);
+            }
+        },
+    );
 }
 
 // Rendered pixel width of one list nesting level. Single source of truth:

--- a/src/platform/codemirror/style-protocol.spec.ts
+++ b/src/platform/codemirror/style-protocol.spec.ts
@@ -15,6 +15,6 @@ describe('drag target and selected-handle styles', () => {
 
     it('styles valid external note targets with the accent color', () => {
         expect(css).toContain('.obsidian-dragger-external-target');
-        expect(css).toMatch(/\.obsidian-dragger-external-target[\s\S]*var\(--interactive-accent\)/);
+        expect(css).toMatch(/\.obsidian-dragger-external-target\s*\{[^}]*var\(--interactive-accent\)/);
     });
 });

--- a/src/platform/codemirror/style-protocol.spec.ts
+++ b/src/platform/codemirror/style-protocol.spec.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(join(process.cwd(), 'styles.css'), 'utf8');
+
+describe('drag target and selected-handle styles', () => {
+    it('keeps selected handles as grips instead of checkmarks', () => {
+        const selectedRules = css.slice(css.indexOf('.md-dragger-handle.is-selected'), css.indexOf('/* 手柄图标样式'));
+
+        expect(selectedRules).not.toContain('rotate(45deg)');
+        expect(selectedRules).not.toContain("content: ''");
+        expect(selectedRules).toContain('var(--interactive-accent)');
+    });
+
+    it('styles valid external note targets with the accent color', () => {
+        expect(css).toContain('.obsidian-dragger-external-target');
+        expect(css).toMatch(/\.obsidian-dragger-external-target[\s\S]*var\(--interactive-accent\)/);
+    });
+});

--- a/src/platform/obsidian/external-note-targets.spec.ts
+++ b/src/platform/obsidian/external-note-targets.spec.ts
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+import { Text } from '@codemirror/state';
+import type { EditorView } from '@codemirror/view';
+import type { DocEdit } from 'md-dragger/domain';
+import type { App } from 'obsidian';
+import { TFile } from 'obsidian';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EXTERNAL_TARGET_ACTIVE_CLASS } from '../../shared/dom-selectors';
+import { createExternalNoteTargets } from './external-note-targets';
+
+function deferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
+function markdownFile(path: string): TFile {
+    const file = new TFile();
+    file.path = path;
+    file.name = path.split('/').at(-1) ?? path;
+    file.basename = file.name.replace(/\.md$/i, '');
+    file.extension = 'md';
+    return file;
+}
+
+function internalLink(href: string): HTMLElement {
+    const link = document.createElement('a');
+    link.className = 'internal-link';
+    link.dataset.href = href;
+    document.body.appendChild(link);
+    return link;
+}
+
+function createHarness(options?: {
+    cachedRead?: (file: TFile) => Promise<string>;
+    process?: (file: TFile, update: (current: string) => string) => Promise<string>;
+    viewForFile?: (file: TFile) => EditorView | null;
+}) {
+    const sourceFile = markdownFile('Source.md');
+    const targetFile = markdownFile('Target.md');
+    let pointedElement: Element | null = internalLink('Target');
+    const cachedRead = vi.fn(options?.cachedRead ?? (async () => 'target'));
+    const process = vi.fn(options?.process ?? (async (_file, update) => update('target')));
+    const getFirstLinkpathDest = vi.fn(() => targetFile);
+    const applyLiveEdits = vi.fn((_edits: DocEdit[]) => undefined);
+    const app = {
+        vault: { cachedRead, process },
+        metadataCache: { getFirstLinkpathDest },
+    } as unknown as App;
+    const service = createExternalNoteTargets({
+        app,
+        sourceFile: () => sourceFile,
+        viewForFile: options?.viewForFile ?? (() => null),
+        elementAtPoint: () => pointedElement,
+        applyLiveEdits,
+    });
+    return {
+        service,
+        sourceFile,
+        targetFile,
+        cachedRead,
+        process,
+        applyLiveEdits,
+        setPointedElement: (element: Element | null) => {
+            pointedElement = element;
+        },
+    };
+}
+
+const point = { x: 10, y: 20 };
+const context = { selection: { blocks: [] } };
+const flushPromises = () => new Promise<void>((resolve) => queueMicrotask(resolve));
+
+beforeEach(() => {
+    document.body.replaceChildren();
+});
+
+describe('external note target lifecycle', () => {
+    it('is handled-invalid while loading and resolves an append position when ready', async () => {
+        const read = deferred<string>();
+        const harness = createHarness({ cachedRead: () => read.promise });
+
+        expect(harness.service.resolve(point, context)).toBeNull();
+        read.resolve('target\nline');
+        await flushPromises();
+
+        const position = harness.service.resolve(point, context);
+        expect(position).toMatchObject({ line: 3, parent: null });
+        expect(document.querySelector('.internal-link')?.classList.contains(EXTERNAL_TARGET_ACTIVE_CLASS)).toBe(true);
+    });
+
+    it('discards a completed read after the pointer leaves the target', async () => {
+        const read = deferred<string>();
+        const harness = createHarness({ cachedRead: () => read.promise });
+
+        expect(harness.service.resolve(point, context)).toBeNull();
+        harness.setPointedElement(null);
+        expect(harness.service.resolve(point, context)).toBeUndefined();
+        read.resolve('stale');
+        await flushPromises();
+
+        expect(harness.service.resolve(point, context)).toBeUndefined();
+        expect(document.querySelector('.internal-link')?.classList.contains(EXTERNAL_TARGET_ACTIVE_CLASS)).toBe(false);
+    });
+
+    it('clears highlighting on clear and destroy', async () => {
+        const harness = createHarness();
+        harness.service.resolve(point, context);
+        await flushPromises();
+        harness.service.resolve(point, context);
+
+        harness.service.clear();
+        expect(document.querySelector('.internal-link')?.classList.contains(EXTERNAL_TARGET_ACTIVE_CLASS)).toBe(false);
+        harness.service.destroy();
+    });
+});
+
+describe('external note target commit', () => {
+    it('persists a rebased destination append before applying source deletion', async () => {
+        const order: string[] = [];
+        let written = '';
+        const harness = createHarness({
+            process: async (_file, update) => {
+                order.push('destination');
+                written = update('newer target text');
+                return written;
+            },
+        });
+        harness.applyLiveEdits.mockImplementation(() => order.push('source'));
+        harness.service.resolve(point, context);
+        await flushPromises();
+        const position = harness.service.resolve(point, context);
+        if (!position) throw new Error('Expected loaded target position');
+        const sourceDoc = Text.of(['source', '', 'keep']);
+        const edits: DocEdit[] = [
+            {
+                doc: position.doc,
+                changes: [{ from: position.doc.length, to: position.doc.length, insert: '\nsource' }],
+            },
+            { doc: sourceDoc, changes: [{ from: 0, to: 7, insert: '' }] },
+        ];
+
+        await harness.service.apply(edits);
+
+        expect(written).toBe('newer target text\nsource');
+        expect(order).toEqual(['destination', 'source']);
+        expect(harness.applyLiveEdits).toHaveBeenCalledWith([edits[1]]);
+    });
+
+    it('leaves live source edits unapplied when destination persistence fails', async () => {
+        const harness = createHarness({ process: async () => Promise.reject(new Error('disk failure')) });
+        harness.service.resolve(point, context);
+        await flushPromises();
+        const position = harness.service.resolve(point, context);
+        if (!position) throw new Error('Expected loaded target position');
+        const sourceDoc = Text.of(['source']);
+        const edits: DocEdit[] = [
+            {
+                doc: position.doc,
+                changes: [{ from: position.doc.length, to: position.doc.length, insert: '\nsource' }],
+            },
+            { doc: sourceDoc, changes: [{ from: 0, to: sourceDoc.length, insert: '' }] },
+        ];
+
+        await expect(harness.service.apply(edits)).rejects.toThrow('disk failure');
+        expect(harness.applyLiveEdits).not.toHaveBeenCalled();
+    });
+
+    it('delegates edits for live editor targets without vault persistence', () => {
+        const liveDoc = Text.of(['open target']);
+        const harness = createHarness({ viewForFile: () => ({ state: { doc: liveDoc } }) as EditorView });
+        const position = harness.service.resolve(point, context);
+        if (!position) throw new Error('Expected live target position');
+        const edits: DocEdit[] = [
+            { doc: liveDoc, changes: [{ from: liveDoc.length, to: liveDoc.length, insert: '\nsource' }] },
+        ];
+
+        harness.service.apply(edits);
+
+        expect(harness.process).not.toHaveBeenCalled();
+        expect(harness.applyLiveEdits).toHaveBeenCalledWith(edits);
+    });
+});

--- a/src/platform/obsidian/external-note-targets.spec.ts
+++ b/src/platform/obsidian/external-note-targets.spec.ts
@@ -35,14 +35,26 @@ function internalLink(href: string): HTMLElement {
     return link;
 }
 
+function livePreviewLink(): HTMLElement {
+    const wrapper = document.createElement('span');
+    wrapper.className = 'cm-hmd-internal-link';
+    const text = document.createElement('span');
+    text.className = 'cm-underline';
+    wrapper.appendChild(text);
+    document.body.appendChild(wrapper);
+    return text;
+}
+
 function createHarness(options?: {
     cachedRead?: (file: TFile) => Promise<string>;
     process?: (file: TFile, update: (current: string) => string) => Promise<string>;
     viewForFile?: (file: TFile) => EditorView | null;
+    pointedElement?: Element | null;
+    linkpathAtPoint?: () => string | null;
 }) {
     const sourceFile = markdownFile('Source.md');
     const targetFile = markdownFile('Target.md');
-    let pointedElement: Element | null = internalLink('Target');
+    let pointedElement: Element | null = options?.pointedElement ?? internalLink('Target');
     const cachedRead = vi.fn(options?.cachedRead ?? (async () => 'target'));
     const process = vi.fn(options?.process ?? (async (_file, update) => update('target')));
     const getFirstLinkpathDest = vi.fn(() => targetFile);
@@ -51,13 +63,15 @@ function createHarness(options?: {
         vault: { cachedRead, process },
         metadataCache: { getFirstLinkpathDest },
     } as unknown as App;
-    const service = createExternalNoteTargets({
+    const dependencies = {
         app,
         sourceFile: () => sourceFile,
         viewForFile: options?.viewForFile ?? (() => null),
         elementAtPoint: () => pointedElement,
+        linkpathAtPoint: options?.linkpathAtPoint ?? (() => null),
         applyLiveEdits,
-    });
+    };
+    const service = createExternalNoteTargets(dependencies);
     return {
         service,
         sourceFile,
@@ -80,6 +94,15 @@ beforeEach(() => {
 });
 
 describe('external note target lifecycle', () => {
+    it('claims a nested Live Preview link instead of falling through to the regular block target', async () => {
+        const harness = createHarness({ pointedElement: livePreviewLink(), linkpathAtPoint: () => 'Target' });
+
+        expect(harness.service.resolve(point, context)).toBeNull();
+        await flushPromises();
+
+        expect(harness.service.resolve(point, context)).toMatchObject({ line: 2, parent: null });
+    });
+
     it('is handled-invalid while loading and resolves an append position when ready', async () => {
         const read = deferred<string>();
         const harness = createHarness({ cachedRead: () => read.promise });

--- a/src/platform/obsidian/external-note-targets.ts
+++ b/src/platform/obsidian/external-note-targets.ts
@@ -1,0 +1,173 @@
+import { Text } from '@codemirror/state';
+import type { EditorView } from '@codemirror/view';
+import { applyCommit } from 'md-dragger/adapter/codemirror';
+import { type BlockSelection, type Doc, type DocEdit, type DropPosition, rebaseAppendChange } from 'md-dragger/domain';
+import type { Point } from 'md-dragger/runtime';
+import type { App, TFile } from 'obsidian';
+import {
+    EXTERNAL_TARGET_ACTIVE_CLASS,
+    FILE_EXPLORER_NOTE_SELECTOR,
+    INTERNAL_LINK_SELECTOR,
+} from '../../shared/dom-selectors';
+import { resolveElementTarget } from './note-drop-target';
+
+type Snapshot = {
+    file: TFile;
+    doc: Doc;
+    text: string;
+};
+
+export type ExternalNoteTargetService = {
+    resolve(point: Point, context: { selection: BlockSelection }): DropPosition | null | undefined;
+    apply(edits: DocEdit[]): Promise<void> | void;
+    clear(): void;
+    destroy(): void;
+};
+
+export type ExternalNoteTargetDependencies = {
+    app: App;
+    sourceFile(): TFile | null;
+    viewForFile(file: TFile): EditorView | null;
+    elementAtPoint(point: Point): Element | null;
+    applyLiveEdits?: (edits: DocEdit[]) => void;
+};
+
+export function createExternalNoteTargets(deps: ExternalNoteTargetDependencies): ExternalNoteTargetService {
+    return new ExternalNoteTargets(deps);
+}
+
+class ExternalNoteTargets implements ExternalNoteTargetService {
+    private activeElement: Element | null = null;
+    private activeFile: TFile | null = null;
+    private snapshot: Snapshot | null = null;
+    private requestToken = 0;
+    private loading = false;
+    private destroyed = false;
+    private readonly snapshotByDoc = new WeakMap<Doc, Snapshot>();
+
+    constructor(private readonly deps: ExternalNoteTargetDependencies) {}
+
+    resolve(point: Point, _context: { selection: BlockSelection }): DropPosition | null | undefined {
+        if (this.destroyed) return undefined;
+        const hit = this.deps.elementAtPoint(point);
+        const element = hit?.closest(`${INTERNAL_LINK_SELECTOR}, ${FILE_EXPLORER_NOTE_SELECTOR}`) ?? null;
+        if (!element) {
+            this.clear();
+            return undefined;
+        }
+
+        const sourceFile = this.deps.sourceFile();
+        const file = sourceFile ? resolveElementTarget(element, sourceFile, this.deps.app) : null;
+        if (!file) {
+            this.clear();
+            return null;
+        }
+
+        const liveView = this.deps.viewForFile(file);
+        if (liveView) {
+            this.activate(element, file);
+            this.snapshot = null;
+            this.loading = false;
+            return { doc: liveView.state.doc, line: liveView.state.doc.lines + 1, parent: null };
+        }
+
+        if (this.activeElement !== element || this.activeFile?.path !== file.path) {
+            this.beginSnapshotLoad(element, file);
+            return null;
+        }
+        if (this.snapshot) {
+            this.markValid(element);
+            return { doc: this.snapshot.doc, line: this.snapshot.doc.lines + 1, parent: null };
+        }
+        if (!this.loading) this.beginSnapshotLoad(element, file);
+        return null;
+    }
+
+    async apply(edits: DocEdit[]): Promise<void> {
+        const externalEdits = edits.filter((edit) => this.snapshotByDoc.has(edit.doc));
+        if (externalEdits.length === 0) {
+            (this.deps.applyLiveEdits ?? applyCommit)(edits);
+            return;
+        }
+        if (externalEdits.length !== 1) throw new Error('Expected one external destination edit');
+
+        const destinationEdit = externalEdits[0];
+        const snapshot = this.snapshotByDoc.get(destinationEdit.doc);
+        if (!snapshot) throw new Error('External destination snapshot is unavailable');
+        const appendChange = destinationEdit.changes.find(
+            (change) =>
+                change.from === snapshot.doc.length && change.to === snapshot.doc.length && change.insert.length > 0,
+        );
+        if (!appendChange) throw new Error('External destination edit is not an append');
+
+        await this.deps.app.vault.process(snapshot.file, (current) => {
+            if (current === snapshot.text) return applyTextChanges(current, destinationEdit);
+            const currentDoc = Text.of(current.split('\n'));
+            const rebased = rebaseAppendChange(snapshot.doc, appendChange, currentDoc);
+            if (!rebased) throw new Error('External destination append could not be rebased');
+            return current.slice(0, rebased.pos) + rebased.text + current.slice(rebased.pos);
+        });
+
+        const liveEdits = edits.filter((edit) => edit !== destinationEdit);
+        (this.deps.applyLiveEdits ?? applyCommit)(liveEdits);
+    }
+
+    clear(): void {
+        this.requestToken += 1;
+        this.activeElement?.classList.remove(EXTERNAL_TARGET_ACTIVE_CLASS);
+        this.activeElement = null;
+        this.activeFile = null;
+        this.snapshot = null;
+        this.loading = false;
+    }
+
+    destroy(): void {
+        this.clear();
+        this.destroyed = true;
+    }
+
+    private activate(element: Element, file: TFile): void {
+        if (this.activeElement !== element) this.activeElement?.classList.remove(EXTERNAL_TARGET_ACTIVE_CLASS);
+        this.activeElement = element;
+        this.activeFile = file;
+        this.requestToken += 1;
+        this.markValid(element);
+    }
+
+    private markValid(element: Element): void {
+        element.classList.add(EXTERNAL_TARGET_ACTIVE_CLASS);
+    }
+
+    private beginSnapshotLoad(element: Element, file: TFile): void {
+        this.activeElement?.classList.remove(EXTERNAL_TARGET_ACTIVE_CLASS);
+        this.activeElement = element;
+        this.activeFile = file;
+        this.snapshot = null;
+        this.loading = true;
+        const token = ++this.requestToken;
+        void this.deps.app.vault.cachedRead(file).then(
+            (text) => {
+                if (this.destroyed || token !== this.requestToken) return;
+                if (this.activeElement !== element || this.activeFile?.path !== file.path) return;
+                const doc = Text.of(text.split('\n'));
+                const snapshot = { file, doc, text };
+                this.snapshot = snapshot;
+                this.snapshotByDoc.set(doc, snapshot);
+                this.loading = false;
+                this.markValid(element);
+            },
+            () => {
+                if (token === this.requestToken) this.loading = false;
+            },
+        );
+    }
+}
+
+function applyTextChanges(text: string, edit: DocEdit): string {
+    let result = text;
+    const changes = [...edit.changes].sort((a, b) => b.from - a.from || b.to - a.to);
+    for (const change of changes) {
+        result = result.slice(0, change.from) + change.insert + result.slice(change.to);
+    }
+    return result;
+}

--- a/src/platform/obsidian/external-note-targets.ts
+++ b/src/platform/obsidian/external-note-targets.ts
@@ -29,6 +29,7 @@ export type ExternalNoteTargetDependencies = {
     sourceFile(): TFile | null;
     viewForFile(file: TFile): EditorView | null;
     elementAtPoint(point: Point): Element | null;
+    linkpathAtPoint(point: Point): string | null;
     applyLiveEdits?: (edits: DocEdit[]) => void;
 };
 
@@ -57,7 +58,9 @@ class ExternalNoteTargets implements ExternalNoteTargetService {
         }
 
         const sourceFile = this.deps.sourceFile();
-        const file = sourceFile ? resolveElementTarget(element, sourceFile, this.deps.app) : null;
+        const file = sourceFile
+            ? resolveElementTarget(element, sourceFile, this.deps.app, this.deps.linkpathAtPoint(point))
+            : null;
         if (!file) {
             this.clear();
             return null;

--- a/src/platform/obsidian/note-drop-target.spec.ts
+++ b/src/platform/obsidian/note-drop-target.spec.ts
@@ -46,6 +46,7 @@ function livePreviewLink(): HTMLElement {
 describe('resolveElementTarget', () => {
     it.each([
         ['Wiki%20Folder/Target.md#Heading', 'Wiki Folder/Target.md'],
+        ['Notes%23Archive', 'Notes#Archive'],
         ['Target|Alias', 'Target'],
         ['Target#^block-id', 'Target'],
     ])('normalizes internal link %s before metadata resolution', (raw, normalized) => {

--- a/src/platform/obsidian/note-drop-target.spec.ts
+++ b/src/platform/obsidian/note-drop-target.spec.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import type { App } from 'obsidian';
+import { TFile } from 'obsidian';
+import { describe, expect, it, vi } from 'vitest';
+import { resolveElementTarget } from './note-drop-target';
+
+function markdownFile(path: string): TFile {
+    const file = new TFile();
+    file.path = path;
+    file.name = path.split('/').at(-1) ?? path;
+    file.basename = file.name.replace(/\.md$/i, '');
+    file.extension = 'md';
+    return file;
+}
+
+function appWithTarget(target: TFile | null) {
+    const getFirstLinkpathDest = vi.fn(() => target);
+    const getAbstractFileByPath = vi.fn(() => target);
+    const app = {
+        metadataCache: { getFirstLinkpathDest },
+        vault: { getAbstractFileByPath },
+    } as unknown as App;
+    return { app, getFirstLinkpathDest, getAbstractFileByPath };
+}
+
+function internalLink(href: string): HTMLElement {
+    const link = document.createElement('a');
+    link.className = 'internal-link';
+    link.dataset.href = href;
+    return link;
+}
+
+function navFile(path: string): HTMLElement {
+    const item = document.createElement('div');
+    item.className = 'nav-file-title';
+    item.dataset.path = path;
+    return item;
+}
+
+describe('resolveElementTarget', () => {
+    it.each([
+        ['Wiki%20Folder/Target.md#Heading', 'Wiki Folder/Target.md'],
+        ['Target|Alias', 'Target'],
+        ['Target#^block-id', 'Target'],
+    ])('normalizes internal link %s before metadata resolution', (raw, normalized) => {
+        const source = markdownFile('Folder/Source.md');
+        const target = markdownFile('Wiki Folder/Target.md');
+        const { app, getFirstLinkpathDest } = appWithTarget(target);
+
+        expect(resolveElementTarget(internalLink(raw), source, app)).toBe(target);
+        expect(getFirstLinkpathDest).toHaveBeenCalledWith(normalized, source.path);
+    });
+
+    it('resolves a markdown File Explorer item by its vault path', () => {
+        const source = markdownFile('Source.md');
+        const target = markdownFile('Notes/Target.md');
+        const { app, getAbstractFileByPath } = appWithTarget(target);
+
+        expect(resolveElementTarget(navFile(target.path), source, app)).toBe(target);
+        expect(getAbstractFileByPath).toHaveBeenCalledWith(target.path);
+    });
+
+    it('rejects folders, non-markdown files, malformed links, and unrelated elements', () => {
+        const source = markdownFile('Source.md');
+        const png = markdownFile('asset.png');
+        png.extension = 'png';
+        const { app } = appWithTarget(png);
+
+        expect(resolveElementTarget(navFile('asset.png'), source, app)).toBeNull();
+        expect(resolveElementTarget(internalLink('%E0%A4%A'), source, app)).toBeNull();
+        expect(resolveElementTarget(document.createElement('div'), source, app)).toBeNull();
+    });
+});

--- a/src/platform/obsidian/note-drop-target.spec.ts
+++ b/src/platform/obsidian/note-drop-target.spec.ts
@@ -2,7 +2,7 @@
 import type { App } from 'obsidian';
 import { TFile } from 'obsidian';
 import { describe, expect, it, vi } from 'vitest';
-import { resolveElementTarget } from './note-drop-target';
+import { internalLinkpathAtOffset, resolveElementTarget } from './note-drop-target';
 
 function markdownFile(path: string): TFile {
     const file = new TFile();
@@ -37,6 +37,12 @@ function navFile(path: string): HTMLElement {
     return item;
 }
 
+function livePreviewLink(): HTMLElement {
+    const link = document.createElement('span');
+    link.className = 'cm-hmd-internal-link';
+    return link;
+}
+
 describe('resolveElementTarget', () => {
     it.each([
         ['Wiki%20Folder/Target.md#Heading', 'Wiki Folder/Target.md'],
@@ -58,6 +64,24 @@ describe('resolveElementTarget', () => {
 
         expect(resolveElementTarget(navFile(target.path), source, app)).toBe(target);
         expect(getAbstractFileByPath).toHaveBeenCalledWith(target.path);
+    });
+
+    it('resolves a Live Preview link using the linkpath read from the editor document', () => {
+        const source = markdownFile('Folder/Source.md');
+        const target = markdownFile('Folder/Target.md');
+        const { app, getFirstLinkpathDest } = appWithTarget(target);
+
+        const resolved = resolveElementTarget(livePreviewLink(), source, app, 'Target#Heading');
+
+        expect(resolved).toBe(target);
+        expect(getFirstLinkpathDest).toHaveBeenCalledWith('Target', source.path);
+    });
+
+    it('extracts the linkpath at a Live Preview document position', () => {
+        expect(internalLinkpathAtOffset('before [[Folder/Target|Alias]] after', 17)).toBe('Folder/Target|Alias');
+        expect(internalLinkpathAtOffset('before [Alias](Folder/Target.md#Heading) after', 17)).toBe(
+            'Folder/Target.md#Heading',
+        );
     });
 
     it('rejects folders, non-markdown files, malformed links, and unrelated elements', () => {

--- a/src/platform/obsidian/note-drop-target.ts
+++ b/src/platform/obsidian/note-drop-target.ts
@@ -1,0 +1,35 @@
+import type { App } from 'obsidian';
+import { TFile } from 'obsidian';
+import { FILE_EXPLORER_NOTE_SELECTOR, INTERNAL_LINK_SELECTOR } from '../../shared/dom-selectors';
+
+export function resolveElementTarget(element: Element, sourceFile: TFile, app: App): TFile | null {
+    if (element.matches(INTERNAL_LINK_SELECTOR)) {
+        const raw = element.getAttribute('data-href') ?? element.getAttribute('href');
+        const linkpath = raw ? normalizeLinkpath(raw) : null;
+        if (!linkpath) return null;
+        return markdownFile(app.metadataCache.getFirstLinkpathDest(linkpath, sourceFile.path));
+    }
+
+    if (element.matches(FILE_EXPLORER_NOTE_SELECTOR)) {
+        const path = element.getAttribute('data-path');
+        if (!path) return null;
+        return markdownFile(app.vault.getAbstractFileByPath(path));
+    }
+
+    return null;
+}
+
+function normalizeLinkpath(raw: string): string | null {
+    try {
+        const decoded = decodeURIComponent(raw);
+        const withoutAlias = decoded.split('|', 1)[0];
+        const withoutSubpath = withoutAlias.split('#', 1)[0].trim();
+        return withoutSubpath || null;
+    } catch {
+        return null;
+    }
+}
+
+function markdownFile(file: unknown): TFile | null {
+    return file instanceof TFile && file.extension.toLowerCase() === 'md' ? file : null;
+}

--- a/src/platform/obsidian/note-drop-target.ts
+++ b/src/platform/obsidian/note-drop-target.ts
@@ -43,10 +43,10 @@ function destinationAtOffset(line: string, offset: number, pattern: RegExp, dest
 
 function normalizeLinkpath(raw: string): string | null {
     try {
-        const decoded = decodeURIComponent(raw);
-        const withoutAlias = decoded.split('|', 1)[0];
-        const withoutSubpath = withoutAlias.split('#', 1)[0].trim();
-        return withoutSubpath || null;
+        const withoutAlias = raw.split('|', 1)[0];
+        const withoutSubpath = withoutAlias.split('#', 1)[0];
+        const decoded = decodeURIComponent(withoutSubpath).trim();
+        return decoded || null;
     } catch {
         return null;
     }

--- a/src/platform/obsidian/note-drop-target.ts
+++ b/src/platform/obsidian/note-drop-target.ts
@@ -2,9 +2,14 @@ import type { App } from 'obsidian';
 import { TFile } from 'obsidian';
 import { FILE_EXPLORER_NOTE_SELECTOR, INTERNAL_LINK_SELECTOR } from '../../shared/dom-selectors';
 
-export function resolveElementTarget(element: Element, sourceFile: TFile, app: App): TFile | null {
+export function resolveElementTarget(
+    element: Element,
+    sourceFile: TFile,
+    app: App,
+    editorLinkpath?: string | null,
+): TFile | null {
     if (element.matches(INTERNAL_LINK_SELECTOR)) {
-        const raw = element.getAttribute('data-href') ?? element.getAttribute('href');
+        const raw = element.getAttribute('data-href') ?? element.getAttribute('href') ?? editorLinkpath;
         const linkpath = raw ? normalizeLinkpath(raw) : null;
         if (!linkpath) return null;
         return markdownFile(app.metadataCache.getFirstLinkpathDest(linkpath, sourceFile.path));
@@ -16,6 +21,23 @@ export function resolveElementTarget(element: Element, sourceFile: TFile, app: A
         return markdownFile(app.vault.getAbstractFileByPath(path));
     }
 
+    return null;
+}
+
+/** Return the Wiki or Markdown link destination covering a line-local offset. */
+export function internalLinkpathAtOffset(line: string, offset: number): string | null {
+    return (
+        destinationAtOffset(line, offset, /\[\[([^\]\n]+)\]\]/g, 1) ??
+        destinationAtOffset(line, offset, /\[[^\]\n]*\]\(([^)\n]+)\)/g, 1)
+    );
+}
+
+function destinationAtOffset(line: string, offset: number, pattern: RegExp, destinationGroup: number): string | null {
+    for (const match of line.matchAll(pattern)) {
+        const start = match.index;
+        const end = start + match[0].length;
+        if (offset >= start && offset <= end) return match[destinationGroup] ?? null;
+    }
     return null;
 }
 

--- a/src/platform/obsidian/views.spec.ts
+++ b/src/platform/obsidian/views.spec.ts
@@ -34,4 +34,15 @@ describe('markdown CodeMirror view lookup', () => {
         expect(getCodeMirrorViewForFile(app, file)).toBe(editorView);
         expect(getCodeMirrorViewForFile(app, markdownFile('Closed.md'))).toBeNull();
     });
+
+    it('continues past a matching leaf without CodeMirror to find a later live view', () => {
+        const editorView = {} as EditorView;
+        const file = markdownFile('Target.md');
+        const app = appWithLeaves([
+            { view: { getViewType: () => 'markdown', file } },
+            { view: { getViewType: () => 'markdown', file, editor: { cm: editorView } } },
+        ]);
+
+        expect(getCodeMirrorViewForFile(app, file)).toBe(editorView);
+    });
 });

--- a/src/platform/obsidian/views.spec.ts
+++ b/src/platform/obsidian/views.spec.ts
@@ -1,0 +1,37 @@
+import type { EditorView } from '@codemirror/view';
+import type { App } from 'obsidian';
+import { TFile } from 'obsidian';
+import { describe, expect, it } from 'vitest';
+import { getCodeMirrorViewForFile, getMarkdownFileForCodeMirror } from './views';
+
+function markdownFile(path: string): TFile {
+    const file = new TFile();
+    file.path = path;
+    file.extension = 'md';
+    return file;
+}
+
+function appWithLeaves(leaves: unknown[]): App {
+    return {
+        workspace: { getLeavesOfType: () => leaves },
+    } as unknown as App;
+}
+
+describe('markdown CodeMirror view lookup', () => {
+    it('finds the source file that owns a CodeMirror view', () => {
+        const editorView = {} as EditorView;
+        const file = markdownFile('Source.md');
+        const app = appWithLeaves([{ view: { getViewType: () => 'markdown', file, editor: { cm: editorView } } }]);
+
+        expect(getMarkdownFileForCodeMirror(app, editorView)).toBe(file);
+    });
+
+    it('finds an open CodeMirror view by file path', () => {
+        const editorView = {} as EditorView;
+        const file = markdownFile('Target.md');
+        const app = appWithLeaves([{ view: { getViewType: () => 'markdown', file, editor: { cm: editorView } } }]);
+
+        expect(getCodeMirrorViewForFile(app, file)).toBe(editorView);
+        expect(getCodeMirrorViewForFile(app, markdownFile('Closed.md'))).toBeNull();
+    });
+});

--- a/src/platform/obsidian/views.ts
+++ b/src/platform/obsidian/views.ts
@@ -32,7 +32,10 @@ export function getCodeMirrorViewForFile(app: App, file: TFile): EditorView | nu
     for (const leaf of app.workspace.getLeavesOfType('markdown')) {
         if (leaf.view.getViewType?.() !== 'markdown') continue;
         const markdownView = leaf.view as MarkdownView;
-        if (markdownView.file?.path === file.path) return getCodeMirrorView(markdownView);
+        if (markdownView.file?.path !== file.path) continue;
+
+        const editorView = getCodeMirrorView(markdownView);
+        if (editorView) return editorView;
     }
     return null;
 }

--- a/src/platform/obsidian/views.ts
+++ b/src/platform/obsidian/views.ts
@@ -1,5 +1,5 @@
 import type { EditorView } from '@codemirror/view';
-import type { App, MarkdownView, WorkspaceLeaf } from 'obsidian';
+import type { App, MarkdownView, TFile, WorkspaceLeaf } from 'obsidian';
 
 export function getActiveMarkdownView(app: App): MarkdownView | null {
     const leaf: WorkspaceLeaf | null = app.workspace.getMostRecentLeaf() ?? null;
@@ -17,4 +17,22 @@ type MarkdownViewWithCm = MarkdownView & {
 export function getCodeMirrorView(markdownView: MarkdownView): EditorView | null {
     const maybeView = (markdownView as MarkdownViewWithCm).editor?.cm;
     return maybeView ?? null;
+}
+
+export function getMarkdownFileForCodeMirror(app: App, editorView: EditorView): TFile | null {
+    for (const leaf of app.workspace.getLeavesOfType('markdown')) {
+        if (leaf.view.getViewType?.() !== 'markdown') continue;
+        const markdownView = leaf.view as MarkdownView;
+        if (getCodeMirrorView(markdownView) === editorView) return markdownView.file ?? null;
+    }
+    return null;
+}
+
+export function getCodeMirrorViewForFile(app: App, file: TFile): EditorView | null {
+    for (const leaf of app.workspace.getLeavesOfType('markdown')) {
+        if (leaf.view.getViewType?.() !== 'markdown') continue;
+        const markdownView = leaf.view as MarkdownView;
+        if (markdownView.file?.path === file.path) return getCodeMirrorView(markdownView);
+    }
+    return null;
 }

--- a/src/shared/dom-selectors.ts
+++ b/src/shared/dom-selectors.ts
@@ -1,6 +1,9 @@
 export const ROOT_EDITOR_CLASS = 'd-root-editor';
 export const DRAGGING_BODY_CLASS = 'd-dragging';
 export const MOBILE_GESTURE_LOCK_CLASS = 'd-mobile-gesture-lock';
+export const INTERNAL_LINK_SELECTOR = '.internal-link';
+export const FILE_EXPLORER_NOTE_SELECTOR = '.nav-file-title[data-path]';
+export const EXTERNAL_TARGET_ACTIVE_CLASS = 'obsidian-dragger-external-target';
 
 export const DRAG_SOURCE_STYLE_ATTR = 'data-d-drag-source-style';
 export const DRAG_SOURCE_HIGHLIGHT_ATTR = 'data-d-drag-source-highlight';

--- a/src/shared/dom-selectors.ts
+++ b/src/shared/dom-selectors.ts
@@ -1,7 +1,7 @@
 export const ROOT_EDITOR_CLASS = 'd-root-editor';
 export const DRAGGING_BODY_CLASS = 'd-dragging';
 export const MOBILE_GESTURE_LOCK_CLASS = 'd-mobile-gesture-lock';
-export const INTERNAL_LINK_SELECTOR = '.internal-link';
+export const INTERNAL_LINK_SELECTOR = '.internal-link, .cm-hmd-internal-link';
 export const FILE_EXPLORER_NOTE_SELECTOR = '.nav-file-title[data-path]';
 export const EXTERNAL_TARGET_ACTIVE_CLASS = 'obsidian-dragger-external-target';
 

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,15 +1,28 @@
 import { vi } from 'vitest';
 
-vi.mock('obsidian', () => ({
-    Platform: {
-        isMobile: false,
-        isMobileApp: false,
-        isPhone: false,
-        isTablet: false,
-        isDesktop: true,
-        isDesktopApp: true,
-    },
-}));
+vi.mock('obsidian', () => {
+    class TFile {
+        path = '';
+        name = '';
+        basename = '';
+        extension = '';
+        parent = null;
+        vault = null;
+        stat = { ctime: 0, mtime: 0, size: 0 };
+    }
+
+    return {
+        Platform: {
+            isMobile: false,
+            isMobileApp: false,
+            isPhone: false,
+            isTablet: false,
+            isDesktop: true,
+            isDesktopApp: true,
+        },
+        TFile,
+    };
+});
 
 if (typeof window !== 'undefined') {
     Object.defineProperty(window, 'activeWindow', {

--- a/styles.css
+++ b/styles.css
@@ -78,35 +78,22 @@
     cursor: grabbing;
 }
 
-/* Multi-select: selected block handles become checkboxes. */
+/* Multi-select: preserve the configured grip and add an accent state. */
 .md-dragger-handle.is-selected,
 .md-dragger-handle.is-selected:hover {
     opacity: 1;
     color: var(--interactive-accent);
     filter: none;
-}
-
-.md-dragger-handle.is-selected .d-handle-core {
-    position: relative;
-    width: 14px;
-    height: 14px;
-    border-radius: 4px;
-    background: var(--interactive-accent);
+    background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
     box-shadow:
         0 0 0 1px color-mix(in srgb, var(--interactive-accent) 72%, var(--background-primary)),
         0 2px 8px color-mix(in srgb, var(--interactive-accent) 28%, transparent);
 }
 
-.md-dragger-handle.is-selected .d-handle-core::before {
-    content: '';
-    position: absolute;
-    left: 4px;
-    top: 2px;
-    width: 4px;
-    height: 7px;
-    border: solid var(--text-on-accent);
-    border-width: 0 2px 2px 0;
-    transform: rotate(45deg);
+.obsidian-dragger-external-target {
+    background-color: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+    outline: 1px solid var(--interactive-accent);
+    border-radius: var(--radius-s, 4px);
 }
 
 .d-handle-core {


### PR DESCRIPTION
> [!IMPORTANT]
> This is a stacked draft depending on Ariestar/md-dragger#25. Local verification uses that engine checkout. Once #25 is merged and released on npm, this PR will update `md-dragger` plus the lockfile and can become ready for review.

## Summary

- use native CodeMirror text selections as semantic multi-block drag selections
- recognize internal links and Markdown File Explorer items as drop targets
- append dragged blocks to open or unopened destination notes
- highlight valid external targets and clear that state across every terminal drag path
- persist the destination before deleting the source, leaving the source untouched when persistence fails

## How this extends issue #35

The existing multi-document commit contract supports dropping into another open editor by routing edits through document identity. The original request in #35 also asked to drop onto a linked page inside the current note or onto a page in the sidebar. Those elements are not editor documents, and their destination may not be open.

This PR adds that missing Obsidian adapter behavior. Engine PR Ariestar/md-dragger#25 supplies the generic selection, external-target, and async-commit hooks; all link, workspace, and vault knowledge remains in this plugin.

## Behavior

- internal links resolve relative to the source note, including URI encoding, aliases, heading links, and block links
- Live Preview links and rendered `.internal-link` anchors are supported
- File Explorer targets use their vault path
- only resolved Markdown files are accepted; folders, non-Markdown files, malformed links, and unresolved links are rejected
- open destinations use their live CodeMirror document
- unopened destinations are read through the vault and updated with `vault.process`
- concurrent destination changes are preserved by rebasing the append at commit time
- link and sidebar drops append at the end of the destination note because those targets do not expose an editor insertion position

## Safety and limitations

Destination persistence completes before source deletion. A failed destination write therefore leaves the source intact. Cross-file undo for an unopened destination cannot be atomic across both files.

## Verification

Against the local checkout of Ariestar/md-dragger#25:

- 10 test files, 77 tests passed
- typecheck passed
- ESLint passed with zero warnings
- Biome format check passed
- production build passed
- plugin bundle smoke check passed
- version synchronization check passed

Manual Obsidian testing confirmed native multi-block selection, Live Preview internal-link drops, and File Explorer drops into unopened notes.

## Follow-up before marking ready

1. Merge and publish Ariestar/md-dragger#25.
2. Update this package dependency and lockfile to that release.
3. Rerun the full verification suite under frozen-lockfile installation.
4. Mark this PR ready for review.

Related: #35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drag and drop blocks across notes using internal links or the file explorer.
  * Select and drag multiple blocks using native editor selections.
  * Support dropping into notes that are not currently open.

* **Bug Fixes**
  * Improved handling of stale, invalid, or failed drop targets and file updates.

* **Style**
  * Added visual highlighting for selected blocks and valid external drop targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->